### PR TITLE
Workaround that "review dog/action-suggester" does not work with forked PR

### DIFF
--- a/.github/workflows/review-suggest.yml
+++ b/.github/workflows/review-suggest.yml
@@ -12,6 +12,9 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
+      # Since "reviewdog/action-suggester" using "spotlessKotlinApply" does not work with forked PR,
+      # perform "spotlessKotlinCheck".
+      - run: ./gradlew spotlessKotlinCheck
       - run: ./gradlew spotlessKotlinApply
       - uses: reviewdog/action-suggester@v1
         with:


### PR DESCRIPTION
## Issue
- related #45

## Overview (Required)
- In this PR, we simply run spotlessKotlinCheck once.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
