### PR TITLE
Fix internal link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 # Guides
 
-- [Development](./#Development)
-  - [Features](./#Features)
-  - [Design](./#Design)
-  - [Try it out](./#Try_it_out)
-  - [Contributing](./#Contributing)
-  - [Requirements](./#Requirements)
-- [Tech Stacks](./#Tech_Stacks)
-  - [Kotlin Multiplatform](./#Kotlin_Multiplatform)
-  - [Jetpack Compose](./#Jetpack_Compose)
-- [Architecture](./#Architecture)
-- [Trouble Shooting](./#Trouble_Shooting)
+- [Development](#Development)
+  - [Features](#Features)
+  - [Design](#Design)
+  - [Try it out](#Try-it-out)
+  - [Contributing](#Contributing)
+  - [Requirements](#Requirements)
+- [Tech Stacks](#Tech-Stacks)
+  - [Kotlin Multiplatform](#Kotlin-Multiplatform)
+  - [Jetpack Compose](#Jetpack-Compose)
+- [Architecture](#Architecture)
+- [Trouble Shooting](#Trouble-Shooting)
 
 # Development
 


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Fixed an issue where internal links in README.md were not working
  - Replace `_` with `-`
  - Remove `./`

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
