### PR TITLE
make authApi non throw exception when server returns 409

### DIFF
--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/AuthApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/AuthApi.kt
@@ -4,10 +4,7 @@ import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.auth
 import io.ktor.client.HttpClient
 import io.ktor.client.features.ResponseException
-import io.ktor.client.features.logging.DEFAULT
-import io.ktor.client.features.logging.Logger
 import io.ktor.client.request.header
-import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/AuthApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/AuthApi.kt
@@ -3,9 +3,15 @@ package io.github.droidkaigi.feeder.data
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.auth
 import io.ktor.client.HttpClient
+import io.ktor.client.features.ResponseException
+import io.ktor.client.features.logging.DEFAULT
+import io.ktor.client.features.logging.Logger
+import io.ktor.client.request.header
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.coroutines.flow.first
 
@@ -43,12 +49,16 @@ class AuthApi(
     }
 
     private suspend fun registerToServer(createdIdToken: String) {
-        httpClient.post<String>("https://ssot-api-staging.an.r.appspot.com/accounts") {
-            headers {
-                set("Authorization", "Bearer $createdIdToken")
+        runCatching {
+            httpClient.post<String>("https://ssot-api-staging.an.r.appspot.com/accounts") {
+                header(HttpHeaders.Authorization, "Bearer $createdIdToken")
+                contentType(ContentType.Application.Json)
+                body = "{}"
             }
-            contentType(ContentType.Application.Json)
-            body = "{}"
+        }.getOrElse {
+            if (it !is ResponseException || it.response.status != HttpStatusCode.Conflict) {
+                throw it
+            }
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #131

## Overview (Required)
- add handling to AuthApi
- I wanted throw appError in getOrElse statements, but appError extends RuntimeException.

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
