### PR TITLE
delete unused namespaces

### DIFF
--- a/uicomponent-compose/feed/src/main/AndroidManifest.xml
+++ b/uicomponent-compose/feed/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.droidkaigi.feeder.feed" />
+<manifest package="io.github.droidkaigi.feeder.feed" />

--- a/uicomponent-compose/main/src/main/AndroidManifest.xml
+++ b/uicomponent-compose/main/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.droidkaigi.feeder.main" />
+<manifest package="io.github.droidkaigi.feeder.main" />

--- a/uicomponent-compose/other/src/main/AndroidManifest.xml
+++ b/uicomponent-compose/other/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.droidkaigi.feeder.other" />
+<manifest package="io.github.droidkaigi.feeder.other" />


### PR DESCRIPTION
## Issue
- close #124

## Overview (Required)
- remove unused namespaces on following modules
  - uicomponent-compose/feed
  - uicomponent-compose/main
  - uicomponent-compose/other

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
