### PR TITLE
Allow to run workflows on contributors's repos

### DIFF
--- a/.github/workflows/assemble-and-stage.yml
+++ b/.github/workflows/assemble-and-stage.yml
@@ -1,33 +1,39 @@
-name: assemble-and-stage
+name: assemble-app
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
   push:
     branches:
       - main
-      - chore/ci_cd_*
 
 jobs:
+  get-pr-number:
+    if: github.event_name == 'pull_request'
+    name: "get-pr-number"
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{ github.event.pull_request.number }}
+        run: echo ok
   assemble:
     if: >
       github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && 
-      !contains(github.event.pull_request.head.ref, 'main') && 
-      !contains(github.event.pull_request.head.ref, 'chore/ci_cd_')
+      github.event_name == 'pull_request' && 
+      !contains(github.event.pull_request.head.ref, 'main')
     name: "assemble android application files"
     runs-on: ubuntu-latest
     steps:
       - name: Get HEAD to fetch
         id: fetch-head
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            echo "::set-output name=ref::refs/pull/${{ github.event.pull_request.number }}/merge"
-          else
+          if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "::set-output name=ref::${{ github.ref }}"
+          else
+            echo "::set-output name=ref::refs/pull/${{ github.event.pull_request.number }}/merge"
           fi
       - uses: actions/checkout@v2
         with:
           ref: ${{ steps.fetch-head.outputs.ref }}
+      - run: rm -fr ./.gh-actions
       - uses: actions/checkout@v2
         with:
           ref: gh-actions
@@ -52,23 +58,23 @@ jobs:
   test:
     if: >
       github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && 
-      !contains(github.event.pull_request.head.ref, 'main') && 
-      !contains(github.event.pull_request.head.ref, 'chore/ci_cd_')
+      github.event_name == 'pull_request' && 
+      !contains(github.event.pull_request.head.ref, 'main')
     name: "test on feature branches"
     runs-on: ubuntu-latest
     steps:
       - name: Get HEAD to fetch
         id: fetch-head
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            echo "::set-output name=ref::refs/pull/${{ github.event.pull_request.number }}/merge"
-          else
+          if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "::set-output name=ref::${{ github.ref }}"
+          else
+            echo "::set-output name=ref::refs/pull/${{ github.event.pull_request.number }}/merge"
           fi
       - uses: actions/checkout@v2
         with:
           ref: ${{ steps.fetch-head.outputs.ref }}
+      - run: rm -fr ./.gh-actions
       - uses: actions/checkout@v2
         with:
           ref: gh-actions
@@ -90,65 +96,6 @@ jobs:
           name: unit-test-reports
           path: "./**/reports"
           retention-days: 14
-  stage-epic:
-    if: github.event_name == 'pull_request_target'
-    needs: [assemble]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: main
-      - uses: actions/checkout@v2
-        with:
-          ref: gh-actions
-          path: gh-actions
-      - uses: actions/download-artifact@v2
-        with:
-          name: assemble-output
-          path: ~/assemble-output
-      - uses: ./gh-actions/actions/find-files
-        id: find-aab-files
-        with:
-          pattern: "~/assemble-output/**/*.aab"
-      - uses: ./gh-actions/actions/create-deployment
-        id: create-deployment
-        with:
-          github-token: ${{ github.token }}
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          sha: ${{ github.event.pull_request.head.sha }}
-          artifact-name: assemble-output
-          environment: deploygate-distribution
-      - uses: jmatsu/dg-upload-app-action@v0.2
-        id: upload
-        continue-on-error: true
-        with:
-          app_owner_name: droidkaigi
-          api_token: ${{ secrets.DEPLOYGATE_API_TOKEN }}
-          app_file_path: ${{ fromJSON(steps.find-aab-files.outputs.paths)[0] }}
-          message: GitHub Actions have staged an artifact of ${{ github.event.pull_request.number }}/head / ${{ github.event.pull_request.head.sha }}
-          distribution_find_by: name
-          distribution_id: ${{ format('debug/refs/pull/{0}/head', github.event.pull_request.number) }}
-          release_note: ${{ format('Workflow {0}/{1} based on {2}', github.run_id , github.run_number , github.event.pull_request.head.sha) }}
-          pin: false
-      - name: generate properties based on upload step's status
-        id: deployment-properties
-        if: steps.upload.conclusion == 'success'
-        run: |
-            if [[ "${{ steps.upload.outcome }}" == "success" ]]; then
-              echo "::set-output name=deployment-url::${{ steps.upload.outputs.distribution_url }}"
-              echo "::set-output name=description::Deployed an app successfully. Please try it through DeployGate!"
-            else
-              echo "::set-output name=deployment-url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-              echo "::set-output name=description::Staging an app failed. Please check the workflow."
-            fi
-      - uses: ./gh-actions/actions/commit-deployment
-        if: steps.upload.conclusion == 'success'
-        with:
-          github-token: ${{ github.token }}
-          deployment-id: ${{ fromJSON(steps.create-deployment.outputs.deployment).id }}
-          state: ${{ steps.upload.outcome }}
-          deployment-url: ${{ steps.deployment-properties.outputs.deployment-url }}
-          description: ${{ steps.deployment-properties.outputs.description }}
   stage-default:
     if: github.event_name == 'push'
     needs: [assemble]

--- a/.github/workflows/assemble-and-stage.yml
+++ b/.github/workflows/assemble-and-stage.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ steps.fetch-head.outputs.ref }}
-      - run: rm -fr ./.gh-actions
+      - run: rm -fr ./gh-actions
       - uses: actions/checkout@v2
         with:
           ref: gh-actions
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ steps.fetch-head.outputs.ref }}
-      - run: rm -fr ./.gh-actions
+      - run: rm -fr ./gh-actions
       - uses: actions/checkout@v2
         with:
           ref: gh-actions

--- a/.github/workflows/drop-staging.yml
+++ b/.github/workflows/drop-staging.yml
@@ -14,7 +14,9 @@ jobs:
   drop-stage:
     name: "Drop from staging"
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/github-script@v3
         id: get-pr-number

--- a/.github/workflows/drop-staging.yml
+++ b/.github/workflows/drop-staging.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/github-script@v3
         id: get-pr-number
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string
           script: |
             const { data: resp } = await github.actions.listJobsForWorkflowRun({

--- a/.github/workflows/stage-app.yml
+++ b/.github/workflows/stage-app.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   stage-epic:
-    needs: [assemble]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/stage-app.yml
+++ b/.github/workflows/stage-app.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   stage-epic:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +48,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const { data: resp } = await github.actions.listArtifactsForWorkflowRun({
+            const { data: resp } = await github.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/stage-app.yml
+++ b/.github/workflows/stage-app.yml
@@ -61,11 +61,15 @@ jobs:
               return '[halt]'
             }
       - uses: ./gh-actions/actions/get-artifact
+        id: get-artifact
         if: steps.get-artifact-id.outputs.result != '[halt]'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-id: ${{ steps.get-artifact-id.outputs.result }}
           path: ~/assemble-output
+      - run: >
+          unzip ${{ steps.get-artifact.outputs.archive-path }} -d ~/assemble-output &&
+          rm -f ${{ steps.get-artifact.outputs.archive-path }}
       - uses: ./gh-actions/actions/find-files
         id: find-aab-files
         with:

--- a/.github/workflows/stage-app.yml
+++ b/.github/workflows/stage-app.yml
@@ -60,7 +60,7 @@ jobs:
             } else {
               return '[halt]'
             }
-      - uses: ./gh-actions/download-artifact
+      - uses: ./gh-actions/actions/get-artifact
         if: steps.get-artifact-id.outputs.result != '[halt]'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stage-app.yml
+++ b/.github/workflows/stage-app.yml
@@ -1,0 +1,109 @@
+name: stage-app
+
+on:
+  workflow_run:
+    workflows:
+      - assemble-app
+    types:
+      - completed
+
+jobs:
+  stage-epic:
+    needs: [assemble]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-actions
+          path: gh-actions
+      - uses: actions/github-script@v3
+        id: get-pr
+        with:
+          script: |
+            const { data: resp } = await github.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }}
+            })
+            const job = resp.jobs.find((j) => j.name === "get-pr-number")
+
+            if (job) {
+              const { data: pull } = await github.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: job.steps[1].name
+              })
+              return pull
+            } else {
+              return '[halt]'
+            }
+      - uses: actions/github-script@v3
+        id: get-artifact-id
+        if: steps.get-pr.outputs.result != '[halt]'
+        with:
+          result-encoding: string
+          script: |
+            const { data: resp } = await github.actions.listArtifactsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }}
+            })
+            const artifact = resp.artifacts.find((a) => a.name === "assemble-output")
+
+            if (artifact) {
+              return artifact.id
+            } else {
+              return '[halt]'
+            }
+      - uses: ./gh-actions/download-artifact
+        if: steps.get-artifact-id.outputs.result != '[halt]'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-id: steps.get-artifact-id.outputs.result
+          path: ~/assemble-output
+      - uses: ./gh-actions/actions/find-files
+        id: find-aab-files
+        with:
+          pattern: "~/assemble-output/**/*.aab"
+      - uses: ./gh-actions/actions/create-deployment
+        id: create-deployment
+        with:
+          github-token: ${{ github.token }}
+          ref: refs/pull/${{ fromJSON(steps.get-pr.outputs.result).number }}/head
+          sha: ${{ fromJSON(steps.get-pr.outputs.result).head.sha }}
+          artifact-name: assemble-output
+          environment: deploygate-distribution
+      - uses: jmatsu/dg-upload-app-action@v0.2
+        id: upload
+        continue-on-error: true
+        with:
+          app_owner_name: droidkaigi
+          api_token: ${{ secrets.DEPLOYGATE_API_TOKEN }}
+          app_file_path: ${{ fromJSON(steps.find-aab-files.outputs.paths)[0] }}
+          message: GitHub Actions have staged an artifact of ${{ fromJSON(steps.get-pr.outputs.result).number }}/head / ${{ fromJSON(steps.get-pr.outputs.result).head.sha }}
+          distribution_find_by: name
+          distribution_id: ${{ format('debug/refs/pull/{0}/head', fromJSON(steps.get-pr.outputs.result).number) }}
+          release_note: ${{ format('Workflow {0}/{1} based on {2}', github.run_id , github.run_number , fromJSON(steps.get-pr.outputs.result).head.sha) }}
+          pin: false
+      - name: generate properties based on upload step's status
+        id: deployment-properties
+        if: steps.upload.conclusion == 'success'
+        run: |
+            if [[ "${{ steps.upload.outcome }}" == "success" ]]; then
+              echo "::set-output name=deployment-url::${{ steps.upload.outputs.distribution_url }}"
+              echo "::set-output name=description::Deployed an app successfully. Please try it through DeployGate!"
+            else
+              echo "::set-output name=deployment-url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+              echo "::set-output name=description::Staging an app failed. Please check the workflow."
+            fi
+      - uses: ./gh-actions/actions/commit-deployment
+        if: steps.upload.conclusion == 'success'
+        with:
+          github-token: ${{ github.token }}
+          deployment-id: ${{ fromJSON(steps.create-deployment.outputs.deployment).id }}
+          state: ${{ steps.upload.outcome }}
+          deployment-url: ${{ steps.deployment-properties.outputs.deployment-url }}
+          description: ${{ steps.deployment-properties.outputs.description }}

--- a/.github/workflows/stage-app.yml
+++ b/.github/workflows/stage-app.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.get-artifact-id.outputs.result != '[halt]'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-id: steps.get-artifact-id.outputs.result
+          artifact-id: ${{ steps.get-artifact-id.outputs.result }}
           path: ~/assemble-output
       - uses: ./gh-actions/actions/find-files
         id: find-aab-files


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- The apparent behavior won't be changed but the assemble workflow (it's the core of the build system) will be run on `pull_request` event. So contributors can modify the workflows if needed.
- This PR may fail due to the difference from the current default branch

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
