### PR TITLE
use action model pattern for navigation

### DIFF
--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -47,10 +47,9 @@ fun AppContent(
         drawerShape = MaterialTheme.shapes.large.copy(all = CornerSize(0.dp)),
         drawerContent = {
             DrawerContent { route ->
-                actions.onSelectDrawerItem(route) {
-                    coroutineScope.launch {
-                        drawerState.close()
-                    }
+                actions.onSelectDrawerItem(route)
+                coroutineScope.launch {
+                    drawerState.close()
                 }
             }
         }
@@ -95,13 +94,10 @@ fun AppContent(
 }
 
 private class AppActions(navController: NavHostController) {
-    val onSelectDrawerItem: (String, () -> Unit) -> Unit = { route, closeDrawer ->
-        try {
-            navController.navigate(route)
-        } finally {
-            closeDrawer()
-        }
+    val onSelectDrawerItem: (String) -> Unit = { route ->
+        navController.navigate(route)
     }
+
     val onSelectFeed: (Context, FeedItem) -> Unit = { context, feedItem ->
         val builder = CustomTabsIntent.Builder()
             .setShowTitle(true)


### PR DESCRIPTION
## Issue
- close #111

## Overview (Required)
- use action model pattern for navigation on AppComponent.kt

- Unable to pass method reference of actions directly...
  - for DrawerContent, close drawer operation is needed
  - for onDetailClick, context instance is needed

Because of above, I wrap method of actions and pass it.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
