### PR TITLE
Make other screen tabs scrollable

### DIFF
--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
@@ -16,9 +16,9 @@ import androidx.compose.material.BackdropValue
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ScrollableTabRow
 import androidx.compose.material.Surface
 import androidx.compose.material.Tab
-import androidx.compose.material.TabRow
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.rememberBackdropScaffoldState
@@ -139,8 +139,9 @@ private fun AppBar(
             }
         }
     )
-    TabRow(
+    ScrollableTabRow(
         selectedTabIndex = 0,
+        edgePadding = 0.dp,
         indicator = {
         },
         divider = {}


### PR DESCRIPTION
## Issue
- close #36

## Overview (Required)
- Change from TabRow to ScrollableTabRow in OtherScreen

## Links
- https://github.com/DroidKaigi/conference-app-2021/pull/148
  - For FeedScreen

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/15137243/109413103-20d66c00-79ef-11eb-8452-6262ab575bd6.png" width="300" /> | <img src="https://user-images.githubusercontent.com/15137243/109413143-51b6a100-79ef-11eb-9766-adf93df1af31.png" width="300" />
