### PR TITLE
Move compose dependencies to Dep.kt

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,9 +111,9 @@ dependencies {
     implementation('androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03')
     kapt Dep.Dagger.hiltAndroidCompiler
 
-    implementation "androidx.compose.runtime:runtime:$compose_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
     implementation Dep.Compose.activity
+    implementation Dep.Compose.runtime
+    implementation Dep.Compose.ui
 
     implementation Dep.Kotlin.bom
     implementation Dep.Kotlin.stdlib

--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -4,6 +4,16 @@ object Dep {
     object Compose {
         const val activity = "androidx.activity:activity-compose:1.3.0-alpha02"
         const val constraintLayout = "androidx.constraintlayout:constraintlayout-compose:1.0.0-alpha03"
+        const val navigation = "androidx.navigation:navigation-compose:1.0.0-alpha08"
+        const val runtime = "androidx.compose.runtime:runtime:1.0.0-beta01"
+        const val livedata = "androidx.compose.runtime:runtime-livedata:1.0.0-beta01"
+        const val foundation = "androidx.compose.foundation:foundation:1.0.0-beta01"
+        const val layout = "androidx.compose.foundation:foundation-layout:1.0.0-beta01"
+        const val ui = "androidx.compose.ui:ui:1.0.0-beta01"
+        const val tooling = "androidx.compose.ui:ui-tooling:1.0.0-beta01"
+        const val material = "androidx.compose.material:material:1.0.0-beta01"
+        const val iconsExtended = "androidx.compose.material:material-icons-extended:1.0.0-beta01"
+        const val animation = "androidx.compose.animation:animation:1.0.0-beta01"
     }
 
     object Jetpack {

--- a/uicomponent-compose/core/build.gradle
+++ b/uicomponent-compose/core/build.gradle
@@ -52,17 +52,16 @@ dependencies {
 
     // Write here to get from JetNews
     // https://github.com/android/compose-samples/blob/master/JetNews/app/build.gradle#L66
-    implementation "androidx.compose.runtime:runtime:$compose_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.foundation:foundation-layout:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    implementation "androidx.compose.animation:animation:$compose_version"
-    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-
-    implementation "androidx.navigation:navigation-compose:$nav_compose_version"
+    implementation Dep.Compose.navigation
+    implementation Dep.Compose.runtime
+    implementation Dep.Compose.livedata
+    implementation Dep.Compose.foundation
+    implementation Dep.Compose.layout
+    implementation Dep.Compose.ui
+    implementation Dep.Compose.tooling
+    implementation Dep.Compose.material
+    implementation Dep.Compose.iconsExtended
+    implementation Dep.Compose.animation
 
     // Android
     implementation Dep.Jetpack.browser

--- a/uicomponent-compose/feed/build.gradle
+++ b/uicomponent-compose/feed/build.gradle
@@ -51,18 +51,17 @@ dependencies {
 
     // Write here to get from JetNews
     // https://github.com/android/compose-samples/blob/master/JetNews/app/build.gradle#L66
-    implementation "androidx.compose.runtime:runtime:$compose_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.foundation:foundation-layout:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    implementation "androidx.compose.animation:animation:$compose_version"
-    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
     implementation Dep.Compose.constraintLayout
-
-    implementation "androidx.navigation:navigation-compose:$nav_compose_version"
+    implementation Dep.Compose.navigation
+    implementation Dep.Compose.runtime
+    implementation Dep.Compose.livedata
+    implementation Dep.Compose.foundation
+    implementation Dep.Compose.layout
+    implementation Dep.Compose.ui
+    implementation Dep.Compose.tooling
+    implementation Dep.Compose.material
+    implementation Dep.Compose.iconsExtended
+    implementation Dep.Compose.animation
 
     // Android
     implementation Dep.Jetpack.browser

--- a/uicomponent-compose/main/build.gradle
+++ b/uicomponent-compose/main/build.gradle
@@ -67,19 +67,17 @@ dependencies {
 
     // Write here to get from JetNews
     // https://github.com/android/compose-samples/blob/master/JetNews/app/build.gradle#L66
-    implementation "androidx.compose.runtime:runtime:$compose_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.foundation:foundation-layout:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    implementation "androidx.compose.animation:animation:$compose_version"
-    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-
-    implementation "androidx.navigation:navigation-compose:$nav_compose_version"
-
     implementation Dep.Compose.activity
+    implementation Dep.Compose.navigation
+    implementation Dep.Compose.runtime
+    implementation Dep.Compose.livedata
+    implementation Dep.Compose.foundation
+    implementation Dep.Compose.layout
+    implementation Dep.Compose.ui
+    implementation Dep.Compose.tooling
+    implementation Dep.Compose.material
+    implementation Dep.Compose.iconsExtended
+    implementation Dep.Compose.animation
 
     // Android
     implementation Dep.Jetpack.browser

--- a/uicomponent-compose/other/build.gradle
+++ b/uicomponent-compose/other/build.gradle
@@ -51,17 +51,16 @@ dependencies {
 
     // Write here to get from JetNews
     // https://github.com/android/compose-samples/blob/master/JetNews/app/build.gradle#L66
-    implementation "androidx.compose.runtime:runtime:$compose_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.foundation:foundation-layout:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    implementation "androidx.compose.animation:animation:$compose_version"
-    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-
-    implementation "androidx.navigation:navigation-compose:$nav_compose_version"
+    implementation Dep.Compose.navigation
+    implementation Dep.Compose.runtime
+    implementation Dep.Compose.livedata
+    implementation Dep.Compose.foundation
+    implementation Dep.Compose.layout
+    implementation Dep.Compose.ui
+    implementation Dep.Compose.tooling
+    implementation Dep.Compose.material
+    implementation Dep.Compose.iconsExtended
+    implementation Dep.Compose.animation
 
     // Android
     implementation Dep.Jetpack.browser


### PR DESCRIPTION
## Issue
- close #65 

## Overview (Required)
- There are some parts that specify direct compose dependencies, so I put them together in `Dep.kt`.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
