### PR TITLE
Fix package staff instead of core for staff screen #104

### DIFF
--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.feeder.viewmodel
 
-import io.github.droidkaigi.feeder.core.StaffViewModel
+import io.github.droidkaigi.feeder.staff.StaffViewModel
 import io.github.droidkaigi.feeder.fakeStaffs
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
@@ -1,7 +1,7 @@
 package io.github.droidkaigi.feeder.viewmodel
 
-import io.github.droidkaigi.feeder.staff.StaffViewModel
 import io.github.droidkaigi.feeder.fakeStaffs
+import io.github.droidkaigi.feeder.staff.StaffViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
@@ -2,7 +2,7 @@ package io.github.droidkaigi.feeder.viewmodel
 
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
-import io.github.droidkaigi.feeder.core.ProvideStaffViewModel
+import io.github.droidkaigi.feeder.staff.ProvideStaffViewModel
 import io.github.droidkaigi.feeder.feed.ProvideFeedViewModel
 
 @Composable

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
@@ -2,8 +2,8 @@ package io.github.droidkaigi.feeder.viewmodel
 
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
-import io.github.droidkaigi.feeder.staff.ProvideStaffViewModel
 import io.github.droidkaigi.feeder.feed.ProvideFeedViewModel
+import io.github.droidkaigi.feeder.staff.ProvideStaffViewModel
 
 @Composable
 fun ProvideViewModels(content: @Composable () -> Unit) {

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealStaffViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealStaffViewModel.kt
@@ -2,7 +2,7 @@ package io.github.droidkaigi.feeder.viewmodel
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.github.droidkaigi.feeder.core.StaffViewModel
+import io.github.droidkaigi.feeder.staff.StaffViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
@@ -35,8 +35,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.accompanist.insets.LocalWindowInsets
 import dev.chrisbanes.accompanist.insets.statusBarsPadding
-import io.github.droidkaigi.feeder.core.AboutThisApp
-import io.github.droidkaigi.feeder.core.StaffList
+import io.github.droidkaigi.feeder.staff.AboutThisApp
+import io.github.droidkaigi.feeder.staff.StaffList
 import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 
 sealed class OtherTabs(val name: String, val routePath: String) {

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
@@ -35,9 +35,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.accompanist.insets.LocalWindowInsets
 import dev.chrisbanes.accompanist.insets.statusBarsPadding
+import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 import io.github.droidkaigi.feeder.staff.AboutThisApp
 import io.github.droidkaigi.feeder.staff.StaffList
-import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 
 sealed class OtherTabs(val name: String, val routePath: String) {
     object AboutThisApp : OtherTabs("About", "about")

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/AboutThisApp.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/AboutThisApp.kt
@@ -1,4 +1,4 @@
-package io.github.droidkaigi.feeder.core
+package io.github.droidkaigi.feeder.staff
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffList.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffList.kt
@@ -1,4 +1,4 @@
-package io.github.droidkaigi.feeder.core
+package io.github.droidkaigi.feeder.staff
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -6,6 +6,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.feeder.core.use
 
 @Composable
 fun StaffList() {

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffViewModel.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffViewModel.kt
@@ -1,10 +1,11 @@
-package io.github.droidkaigi.feeder.core
+package io.github.droidkaigi.feeder.staff
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import io.github.droidkaigi.feeder.AppError
 import io.github.droidkaigi.feeder.Staff
+import io.github.droidkaigi.feeder.core.UnidirectionalViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 


### PR DESCRIPTION
## Issue
- close #104

## Overview (Required)
- rename "io.github.droidkaigi.feeder.core" to "io.github.droidkaigi.feeder.staff" and update import lines accordingly

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
