### PR TITLE
stop generating BuildConfig

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,6 +72,7 @@ android {
     }
     buildFeatures {
         compose true
+        buildConfig false
     }
     composeOptions {
         kotlinCompilerExtensionVersion "${compose_version}"


### PR DESCRIPTION
## Issue
- close #125

## Overview (Required)
- Set `buildConfig` property to false at android.buildFeatures of android/build.gradle.

## Links
You can get a detailed explanation of this property from the link below.
https://developer.android.com/reference/tools/gradle-api/7.0/com/android/build/api/dsl/BuildFeatures#buildconfig

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
