### PR TITLE
Prevent backdrop from moving up and down on other screen

### DIFF
--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
@@ -83,6 +83,7 @@ fun OtherScreen(
     Column {
         val density = LocalDensity.current
         BackdropScaffold(
+            gesturesEnabled = false,
             backLayerBackgroundColor = MaterialTheme.colors.primary,
             scaffoldState = scaffoldState,
             backLayerContent = {


### PR DESCRIPTION
## Issue
- close #85 

## Overview (Required)
-  Fix `BackdropScaffold#gesturesEnabled` value to `false`  on other screen.

## Links
-

## Screenshot
https://user-images.githubusercontent.com/70118729/109441257-22984200-7a78-11eb-9763-603cdc004faf.mp4
