### PR TITLE
Implement FakeViewModel and FakeViewModelTest for "Staff" screen

### DIFF
--- a/android/src/test/java/io/github/droidkaigi/feeder/StaffViewModelTest.kt
+++ b/android/src/test/java/io/github/droidkaigi/feeder/StaffViewModelTest.kt
@@ -1,0 +1,63 @@
+package io.github.droidkaigi.feeder
+
+import io.github.droidkaigi.feeder.staff.StaffViewModel
+import io.github.droidkaigi.feeder.viewmodel.fakeStaffViewModel
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@InternalCoroutinesApi
+@RunWith(Parameterized::class)
+class StaffViewModelTest(
+    val name: String,
+    private val staffViewModelFactory: StaffViewModelFactory,
+) {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @Test
+    fun contents() = coroutineTestRule.testDispatcher.runBlockingTest {
+        val staffViewModel = staffViewModelFactory.create()
+        val staffContents = staffViewModel.state.value.staffContents
+        staffContents.size shouldBeGreaterThan 1
+    }
+
+
+    @Test
+    fun errorWhenFetch() = coroutineTestRule.testDispatcher.runBlockingTest {
+        val staffViewModel = staffViewModelFactory.create(errorFetchData = true)
+        val firstEffect = staffViewModel.effect.first()
+        firstEffect.shouldBeInstanceOf<StaffViewModel.Effect.ErrorMessage>()
+    }
+
+    class StaffViewModelFactory(
+        private val viewModelFactory: (errorFetchData: Boolean) ->
+        StaffViewModel,
+    ) {
+        fun create(
+            errorFetchData: Boolean = false,
+        ): StaffViewModel {
+            return viewModelFactory(errorFetchData)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data() = listOf(
+            arrayOf(
+                "FakeViewModel",
+                StaffViewModelFactory { errorFetchData: Boolean ->
+                    fakeStaffViewModel(errorFetchData = errorFetchData)
+                }
+            )
+        )
+    }
+}

--- a/android/src/test/java/io/github/droidkaigi/feeder/StaffViewModelTest.kt
+++ b/android/src/test/java/io/github/droidkaigi/feeder/StaffViewModelTest.kt
@@ -1,7 +1,7 @@
 package io.github.droidkaigi.feeder
 
 import io.github.droidkaigi.feeder.staff.StaffViewModel
-import io.github.droidkaigi.feeder.viewmodel.fakeStaffViewModel
+import io.github.droidkaigi.feeder.staff.fakeStaffViewModel
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.InternalCoroutinesApi

--- a/android/src/test/java/io/github/droidkaigi/feeder/StaffViewModelTest.kt
+++ b/android/src/test/java/io/github/droidkaigi/feeder/StaffViewModelTest.kt
@@ -29,7 +29,6 @@ class StaffViewModelTest(
         staffContents.size shouldBeGreaterThan 1
     }
 
-
     @Test
     fun errorWhenFetch() = coroutineTestRule.testDispatcher.runBlockingTest {
         val staffViewModel = staffViewModelFactory.create(errorFetchData = true)

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
@@ -4,6 +4,7 @@ import io.github.droidkaigi.feeder.AppError
 import io.github.droidkaigi.feeder.Staff
 import io.github.droidkaigi.feeder.fakeStaffs
 import io.github.droidkaigi.feeder.staff.StaffViewModel
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -16,7 +17,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
-import kotlin.coroutines.CoroutineContext
 
 fun fakeStaffViewModel(errorFetchData: Boolean = false) = FakeStaffViewModel(errorFetchData)
 class FakeStaffViewModel(errorFetchData: Boolean) : StaffViewModel {

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
@@ -1,24 +1,61 @@
 package io.github.droidkaigi.feeder.viewmodel
 
+import io.github.droidkaigi.feeder.AppError
+import io.github.droidkaigi.feeder.Staff
 import io.github.droidkaigi.feeder.fakeStaffs
 import io.github.droidkaigi.feeder.staff.StaffViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlin.coroutines.CoroutineContext
 
-fun fakeStaffViewModel() = FakeStaffViewModel()
-class FakeStaffViewModel : StaffViewModel {
-    override val state: StateFlow<StaffViewModel.State> = MutableStateFlow(
-        StaffViewModel.State(
-            showProgress = false,
-            staffContents = fakeStaffs()
-        )
-    )
+fun fakeStaffViewModel(errorFetchData: Boolean = false) = FakeStaffViewModel(errorFetchData)
+class FakeStaffViewModel(errorFetchData: Boolean) : StaffViewModel {
 
     private val effectChannel = Channel<StaffViewModel.Effect>(Channel.UNLIMITED)
     override val effect: Flow<StaffViewModel.Effect> = effectChannel.receiveAsFlow()
+
+    private val coroutineScope = CoroutineScope(
+        object : CoroutineDispatcher() {
+            // for preview
+            override fun dispatch(context: CoroutineContext, block: Runnable) {
+                block.run()
+            }
+        }
+    )
+
+    private val mutableStaffs = MutableStateFlow(
+        fakeStaffs()
+    )
+
+    private val errorStaffs = flow<List<Staff>> {
+        throw AppError.ApiException.ServerException(null)
+    }.catch { error ->
+        effectChannel.send(StaffViewModel.Effect.ErrorMessage(error as AppError))
+    }.stateIn(coroutineScope, SharingStarted.Lazily, fakeStaffs())
+
+    private val mStaffs: StateFlow<List<Staff>> = if (errorFetchData) {
+        errorStaffs
+    } else {
+        mutableStaffs
+    }
+
+    override val state: StateFlow<StaffViewModel.State> = mStaffs.map {
+        StaffViewModel.State(
+            showProgress = false,
+            staffContents = it
+        )
+    }.stateIn(coroutineScope, SharingStarted.Eagerly, StaffViewModel.State())
+
     override fun event(event: StaffViewModel.Event) {
     }
 }

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/FakeStaffViewModel.kt
@@ -33,23 +33,23 @@ class FakeStaffViewModel(errorFetchData: Boolean) : StaffViewModel {
         }
     )
 
-    private val mutableStaffs = MutableStateFlow(
+    private val mutableStaffContents = MutableStateFlow(
         fakeStaffs()
     )
 
-    private val errorStaffs = flow<List<Staff>> {
+    private val errorStaffContents = flow<List<Staff>> {
         throw AppError.ApiException.ServerException(null)
     }.catch { error ->
         effectChannel.send(StaffViewModel.Effect.ErrorMessage(error as AppError))
     }.stateIn(coroutineScope, SharingStarted.Lazily, fakeStaffs())
 
-    private val mStaffs: StateFlow<List<Staff>> = if (errorFetchData) {
-        errorStaffs
+    private val mStaffContents: StateFlow<List<Staff>> = if (errorFetchData) {
+        errorStaffContents
     } else {
-        mutableStaffs
+        mutableStaffContents
     }
 
-    override val state: StateFlow<StaffViewModel.State> = mStaffs.map {
+    override val state: StateFlow<StaffViewModel.State> = mStaffContents.map {
         StaffViewModel.State(
             showProgress = false,
             staffContents = it

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.droidkaigi.feeder.feed.ProvideFeedViewModel
 import io.github.droidkaigi.feeder.staff.ProvideStaffViewModel
+import io.github.droidkaigi.feeder.staff.fakeStaffViewModel
 
 @Composable
 fun ProvideViewModels(content: @Composable () -> Unit) {

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/FakeStaffViewModel.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/FakeStaffViewModel.kt
@@ -1,9 +1,8 @@
-package io.github.droidkaigi.feeder.viewmodel
+package io.github.droidkaigi.feeder.staff
 
 import io.github.droidkaigi.feeder.AppError
 import io.github.droidkaigi.feeder.Staff
 import io.github.droidkaigi.feeder.fakeStaffs
-import io.github.droidkaigi.feeder.staff.StaffViewModel
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope


### PR DESCRIPTION
## Issue
- close #18

## Overview (Required)

- Implements FakeStaffViewModel
- Implements StaffViewModelTest
- Move FakeStaffViewModel to `other` module and `io.github.droidkaigi.feeder.staff` package because   [FakeContributorViewModel](https://github.com/DroidKaigi/conference-app-2021/blob/main/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/FakeContributorViewModel.kt) is in `other` module and `io.github.droidkaigi.feeder.contributor` package.

## Links

- [FakeFeedViewModel](https://github.com/DroidKaigi/conference-app-2021/blob/main/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FakeFeedViewModel.kt)
- [FeedItemViewModelTest](https://github.com/DroidKaigi/conference-app-2021/blob/main/android/src/test/java/io/github/droidkaigi/feeder/FeedItemViewModelTest.kt)
- [FakeContributorViewModel](https://github.com/DroidKaigi/conference-app-2021/blob/main/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/FakeContributorViewModel.kt)
- [ContributorViewModelTest](https://github.com/DroidKaigi/conference-app-2021/blob/main/android/src/test/java/io/github/droidkaigi/feeder/ContributorViewModelTest.kt)
