### PR TITLE
Keep the splash screen finished through screen rotation

### DIFF
--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DroidKaigiApp.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DroidKaigiApp.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -16,7 +16,7 @@ import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 @Composable
 fun DroidKaigiApp(firstSplashScreenState: SplashState = SplashState.Shown) {
     ConferenceAppFeederTheme {
-        var splashShown by remember {
+        var splashShown by rememberSaveable {
             mutableStateOf(firstSplashScreenState)
         }
         val transition = updateTransition(splashShown)


### PR DESCRIPTION
## Issue
- close #126

## Overview (Required)
- Save splashShown state using `rememberSaveable`, instead of `remember`.

## Links
- ~~https://developer.android.com/jetpack/compose/state#restore-ui-state~~
  > `savedInstanceState()` is no longer available.
- Deprecate `savedInstanceState()`
  https://android-review.googlesource.com/c/platform/frameworks/support/+/1561977

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3405740/109514005-fd8fe780-7ae8-11eb-91da-d708f0b454e4.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/109513976-f8cb3380-7ae8-11eb-982d-7245ec4c228f.gif" width="300" />