### PR TITLE
Fix padding when side navigation bar

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -214,7 +214,8 @@ private fun FeedList(
         modifier = Modifier.fillMaxHeight()
     ) {
         LazyColumn(
-            contentPadding = LocalWindowInsets.current.systemBars.toPaddingValues(top = false)
+            contentPadding = LocalWindowInsets.current.systemBars
+                .toPaddingValues(top = false, start = false, end = false)
         ) {
             if (feedContents.size > 0) {
                 items(feedContents.contents.size * 2) { index ->

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DroidKaigiApp.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DroidKaigiApp.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import dev.chrisbanes.accompanist.insets.navigationBarsPadding
 import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 
 @Composable
@@ -41,6 +42,7 @@ fun DroidKaigiApp(firstSplashScreenState: SplashState = SplashState.Shown) {
         AppContent(
             modifier = Modifier
                 .alpha(contentAlpha)
+                .navigationBarsPadding(bottom = false)
         )
     }
 }


### PR DESCRIPTION
## Issue
- close #212

## Overview (Required)
- Add side paddings on `AppContent` using `navigationBarsPadding()`. (landscape, seascape only)
- And remove unnecessary side paddings of `FeedList`.

## Links
- https://chrisbanes.github.io/accompanist/insets/

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3405740/109522220-63806d00-7af1-11eb-8755-78a6e537040b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/109522202-5fece600-7af1-11eb-8732-0c80cae933d5.png" width="300" />
<img src="https://user-images.githubusercontent.com/3405740/109523418-b0b10e80-7af2-11eb-82dc-3edcd44611c5.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/109523408-ae4eb480-7af2-11eb-9dfa-067ed0fd9064.png" width="300" />
<img src="https://user-images.githubusercontent.com/3405740/109522221-64190380-7af1-11eb-82d4-b0b9909642a1.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/109522210-624f4000-7af1-11eb-962b-e0b5150ed950.png" width="300" />
<img src="https://user-images.githubusercontent.com/3405740/109523421-b149a500-7af2-11eb-8f37-7c910d1bc0e9.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/109523414-af7fe180-7af2-11eb-846d-2fa45e9c8d16.png" width="300" />
