### PR TITLE
add implementation of 'onMessageReceived' #41

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -19,8 +19,18 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+                <data
+                    android:host="@string/deep_link_host"
+                    android:path="@string/deep_link_path"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_logo" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/blue_200" />
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/android/src/main/java/io/github/droidkaigi/feeder/notification/AppMessagingService.kt
+++ b/android/src/main/java/io/github/droidkaigi/feeder/notification/AppMessagingService.kt
@@ -5,11 +5,12 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
 import io.github.droidkaigi.feeder.repository.DeviceRepository
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AppMessagingService : FirebaseMessagingService() {
@@ -17,9 +18,7 @@ class AppMessagingService : FirebaseMessagingService() {
     @Inject
     lateinit var deviceRepository: DeviceRepository
 
-    private val serviceJob: Job = Job()
-
-    private val serviceScope: CoroutineScope = CoroutineScope(Dispatchers.IO + serviceJob)
+    private val serviceScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     override fun onCreate() {
         super.onCreate()
@@ -37,12 +36,17 @@ class AppMessagingService : FirebaseMessagingService() {
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
-        // TODO: 2021/02/28 add handling
-        NotificationUtil.showNotifications()
+        runCatching {
+            remoteMessage.notification?.let {
+                NotificationUtil.showNotifications(this, it, remoteMessage.data)
+            } ?: Log.w(TAG, "notification not found")
+        }.onFailure {
+            Log.e(TAG, "notification failed", it)
+        }
     }
 
     override fun onDestroy() {
-        serviceJob.cancel()
+        serviceScope.cancel()
         super.onDestroy()
     }
 

--- a/android/src/main/java/io/github/droidkaigi/feeder/notification/AppMessagingService.kt
+++ b/android/src/main/java/io/github/droidkaigi/feeder/notification/AppMessagingService.kt
@@ -5,12 +5,12 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
 import io.github.droidkaigi.feeder.repository.DeviceRepository
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class AppMessagingService : FirebaseMessagingService() {

--- a/android/src/main/java/io/github/droidkaigi/feeder/notification/AppNotificationChannel.kt
+++ b/android/src/main/java/io/github/droidkaigi/feeder/notification/AppNotificationChannel.kt
@@ -10,15 +10,24 @@ enum class AppNotificationChannel(
     @StringRes val channelName: Int,
     val importance: Int,
 ) {
-    DEFAULT(
-        "default_channel",
-        R.string.notification_channel_name_default,
-        NotificationManagerCompat.IMPORTANCE_DEFAULT
-    ),
-
     ANNOUNCEMENT(
         "announcement",
         R.string.notification_channel_name_announcement,
+        NotificationManagerCompat.IMPORTANCE_DEFAULT
+    ),
+    BLOG(
+        "blog",
+        R.string.notification_channel_name_blog,
+        NotificationManagerCompat.IMPORTANCE_DEFAULT
+    ),
+    VIDEO(
+        "video",
+        R.string.notification_channel_name_video,
+        NotificationManagerCompat.IMPORTANCE_DEFAULT
+    ),
+    PODCAST(
+        "podcast",
+        R.string.notification_channel_name_podcast,
         NotificationManagerCompat.IMPORTANCE_DEFAULT
     );
 
@@ -27,7 +36,7 @@ enum class AppNotificationChannel(
     companion object {
         @JvmStatic
         fun fromId(id: String): AppNotificationChannel {
-            return values().find { it.id == id } ?: DEFAULT
+            return values().find { it.id == id } ?: ANNOUNCEMENT
         }
     }
 }

--- a/android/src/main/java/io/github/droidkaigi/feeder/notification/NotificationUtil.kt
+++ b/android/src/main/java/io/github/droidkaigi/feeder/notification/NotificationUtil.kt
@@ -1,9 +1,17 @@
 package io.github.droidkaigi.feeder.notification
 
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.os.bundleOf
+import com.google.firebase.messaging.RemoteMessage
+import io.github.droidkaigi.feeder.MainActivity
+import io.github.droidkaigi.feeder.R
 
 object NotificationUtil {
     @JvmStatic
@@ -37,7 +45,55 @@ object NotificationUtil {
     }
 
     @JvmStatic
-    fun showNotifications() {
-        // TODO: 2021/02/28 add implementation
+    fun showNotifications(
+        context: Context,
+        remoteNotification: RemoteMessage.Notification,
+        data: Map<String, String>,
+    ) {
+        val channel = AppNotificationChannel.fromId(remoteNotification.channelId ?: "")
+        val manager = NotificationManagerCompat.from(context)
+        val notification = NotificationCompat.Builder(context, channel.id)
+            .setSmallIcon(R.drawable.ic_logo)
+            .setContentTitle(remoteNotification.title)
+            .setContentText(remoteNotification.body)
+            .setAutoCancel(true)
+            .setStyle(
+                NotificationCompat.BigTextStyle()
+                    .setBigContentTitle(remoteNotification.title)
+                    .bigText(remoteNotification.body)
+            )
+            .setContentIntent(
+                getPendingIntent(
+                    context,
+                    remoteNotification.link,
+                    data
+                )
+            )
+            .build()
+        manager.notify(channel.id.hashCode(), notification)
+    }
+
+    @JvmStatic
+    private fun getPendingIntent(
+        context: Context,
+        link: Uri?,
+        data: Map<String, Any>,
+    ): PendingIntent {
+        val options = bundleOf(*data.map { it.key to it.value }.toTypedArray())
+        val deepLink = link ?: (data["link"] as? String)?.let { Uri.parse(it) }
+
+        val intent = if (deepLink != null) {
+            Intent(Intent.ACTION_VIEW, deepLink, context, MainActivity::class.java)
+        } else {
+            Intent(context, MainActivity::class.java)
+        }
+
+        return PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT,
+            options
+        )
     }
 }

--- a/android/src/main/res/values-ja/strings.xml
+++ b/android/src/main/res/values-ja/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <!-- Notification -->
-    <string name="notification_channel_name_default">お知らせ</string>
     <string name="notification_channel_name_announcement">運営からの広報</string>
+    <string name="notification_channel_name_blog">ブログ更新</string>
+    <string name="notification_channel_name_video">ビデオ更新</string>
+    <string name="notification_channel_name_podcast">ポッドキャスト更新</string>
 </resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
     <string name="app_name" translatable="false">DroidKaigi 2021</string>
 
     <!-- Notification -->
-    <string name="notification_channel_name_default">Notification</string>
     <string name="notification_channel_name_announcement">Announcement</string>
+    <string name="notification_channel_name_blog">Blog Update</string>
+    <string name="notification_channel_name_video">Video Update</string>
+    <string name="notification_channel_name_podcast">Podcast Update</string>
 </resources>

--- a/uicomponent-compose/core/src/main/res/values/deep-link.xml
+++ b/uicomponent-compose/core/src/main/res/values/deep-link.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="deep_link_host" translatable="false">droidkaigi.jp</string>
+    <string name="deep_link_path" translatable="false">/2021</string>
+</resources>

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -23,8 +23,10 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.navArgument
 import androidx.navigation.compose.navigate
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navDeepLink
 import io.github.droidkaigi.feeder.feed.FeedScreen
 import io.github.droidkaigi.feeder.feed.FeedTabs
+import io.github.droidkaigi.feeder.main.R
 import io.github.droidkaigi.feeder.other.OtherScreen
 import io.github.droidkaigi.feeder.other.OtherTabs
 import kotlinx.coroutines.launch
@@ -42,6 +44,9 @@ fun AppContent(
             drawerState.open()
         }
     }
+    val deepLinkUri =
+        "https://" + LocalContext.current.getString(R.string.deep_link_host) +
+            LocalContext.current.getString(R.string.deep_link_path)
     val actions = remember(navController) { AppActions(navController) }
     ModalDrawer(
         modifier = modifier,
@@ -65,6 +70,7 @@ fun AppContent(
         NavHost(navController, startDestination = "feed/{feedTab}") {
             composable(
                 route = "feed/{feedTab}",
+                deepLinks = listOf(navDeepLink { uriPattern = "$deepLinkUri/feed/{feedTab}" }),
                 arguments = listOf(
                     navArgument("feedTab") {
                         type = NavType.StringType
@@ -85,6 +91,7 @@ fun AppContent(
             }
             composable(
                 route = "other/{otherTab}",
+                deepLinks = listOf(navDeepLink { uriPattern = "$deepLinkUri/other/{otherTab}" }),
                 arguments = listOf(
                     navArgument("otherTab") {
                         type = NavType.StringType


### PR DESCRIPTION
## Issue
- close #41

## Overview (Required)
- add implementation of 'onMessageReceived'
- make CoroutineScope in Service uses SupervisorJob ☞ [comment](https://github.com/DroidKaigi/conference-app-2021/pull/185#discussion_r584396531) 
- add DeepLink to feed tab
- I will upload a video of deepLink(I missed to take videos.... very flicking... 😭 )
- I'm facing a problem about 'How DeepLink transition to another screen without Splash' 🙇  
- maybe, I should add some implementations to handling to receive notification in background
- I assumed push payload like this 👇
```
{
  "notification":{
      "title":"title",
      "body":"body"
    },
    "data" : {
      "link" : "Uri to tab",
      and more....
    }
}

```

## Links
- https://developer.android.com/jetpack/compose/navigation#deeplinks

## Screenshot
Foreground to Blog tab | Wakeup App
:--: | :--:
<video src="https://user-images.githubusercontent.com/32740480/109536636-4fdd0280-7b01-11eb-8612-4473b1cea91f.mp4" width="300" /> | <video  src="https://user-images.githubusercontent.com/32740480/109536660-58353d80-7b01-11eb-9617-06d94ca144fc.mp4" width="300" />

