### PR TITLE
Remove divider displayed above the first item in feed lists

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -234,7 +234,7 @@ private fun FeedList(
         ) {
             if (feedContents.size > 0) {
                 items(feedContents.contents.size * 2) { index ->
-                    if (index % 2 == 0) {
+                    if (index % 2 == 0 && index != 0) {
                         Divider()
                     } else {
                         val (item, favorited) = feedContents.contents[index / 2]


### PR DESCRIPTION
## Issue
- close #211 

## Overview (Required)
- remove divider in the first item

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/45986582/109656424-c16f8c00-7ba7-11eb-872c-0d387cb94cc8.png" width="300" /> | <img src="https://user-images.githubusercontent.com/45986582/109656523-dc420080-7ba7-11eb-8ad3-a0d935c08456.png" width="300" />
