### PR TITLE
Fix to remove border of feed item image

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedItem.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedItem.kt
@@ -82,7 +82,7 @@ fun FeedItem(
                 }
                 .width(96.dp)
 //                .aspectRatio(16F / 9F)
-                .aspectRatio(1F / 1F).border(1.dp, Color.Black),
+                .aspectRatio(1F / 1F),
             contentScale = ContentScale.Crop,
             contentDescription = null
         )

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedItem.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedItem.kt
@@ -1,7 +1,6 @@
 package io.github.droidkaigi.feeder.feed
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio


### PR DESCRIPTION
## Issue
- close #240

## Overview (Required)
- Bug Fix. Remove border of feed item image that are not in the Figma design.

## Links
- https://www.figma.com/file/IFlrbfmBSdYvUz7VmSzfLV/DroidKaigi_2021_official_app?node-id=1%3A305

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/32348624/109656514-d9471000-7ba7-11eb-8a52-234c5d34b59d.png" width="300" /> | <img src="https://user-images.githubusercontent.com/32348624/109656525-dd732d80-7ba7-11eb-8008-e97cd56fbd98.png" width="300" />
