### PR TITLE
Apply android gradle from uicomponent compose modules

### DIFF
--- a/uicomponent-compose/core/build.gradle
+++ b/uicomponent-compose/core/build.gradle
@@ -6,14 +6,9 @@ plugins {
     id 'app.cash.exhaustive'
 }
 
-android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+apply from: rootProject.file("gradle/android.gradle")
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
-    }
+android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/uicomponent-compose/feed/build.gradle
+++ b/uicomponent-compose/feed/build.gradle
@@ -6,14 +6,9 @@ plugins {
     id 'app.cash.exhaustive'
 }
 
-android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+apply from: rootProject.file("gradle/android.gradle")
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
-    }
+android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/uicomponent-compose/main/build.gradle
+++ b/uicomponent-compose/main/build.gradle
@@ -8,14 +8,9 @@ plugins {
     id 'dagger.hilt.android.plugin'
 }
 
-android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+apply from: rootProject.file("gradle/android.gradle")
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
-    }
+android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/uicomponent-compose/other/build.gradle
+++ b/uicomponent-compose/other/build.gradle
@@ -9,6 +9,10 @@ plugins {
 apply from: rootProject.file("gradle/android.gradle")
 
 android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += "-Xopt-in=androidx.compose.material.ExperimentalMaterialApi"

--- a/uicomponent-compose/other/build.gradle
+++ b/uicomponent-compose/other/build.gradle
@@ -6,18 +6,9 @@ plugins {
     id 'app.cash.exhaustive'
 }
 
-android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+apply from: rootProject.file("gradle/android.gradle")
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+android {
     kotlinOptions {
         jvmTarget = '1.8'
         freeCompilerArgs += "-Xopt-in=androidx.compose.material.ExperimentalMaterialApi"


### PR DESCRIPTION
## Issue

- close #122

## Overview (Required)

- By applying gradle/android.gradle to uicomponent-compose modules, redundant configuration is deleted.
