### PR TITLE
Delete compose_version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,5 @@
 import io.github.droidkaigi.feeder.Dep
+import io.github.droidkaigi.feeder.Versions
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
@@ -75,7 +76,7 @@ android {
         buildConfig false
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "${compose_version}"
+        kotlinCompilerExtensionVersion "${Versions.compose}"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,7 @@
 import io.github.droidkaigi.feeder.Dep
-import io.github.droidkaigi.feeder.Versions
 
 buildscript {
     ext {
-        compose_version = Versions.compose
         nav_compose_version = "1.0.0-alpha08"
         kotlin_version = "1.4.30"
     }

--- a/uicomponent-compose/core/build.gradle
+++ b/uicomponent-compose/core/build.gradle
@@ -1,4 +1,5 @@
 import io.github.droidkaigi.feeder.Dep
+import io.github.droidkaigi.feeder.Versions
 // TODO: make this library Kotlin MPP
 plugins {
     id 'com.android.library'
@@ -22,7 +23,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "${compose_version}"
+        kotlinCompilerExtensionVersion "${Versions.compose}"
     }
 }
 

--- a/uicomponent-compose/feed/build.gradle
+++ b/uicomponent-compose/feed/build.gradle
@@ -1,4 +1,5 @@
 import io.github.droidkaigi.feeder.Dep
+import io.github.droidkaigi.feeder.Versions
 // TODO: make this library Kotlin MPP
 plugins {
     id 'com.android.library'
@@ -22,7 +23,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "${compose_version}"
+        kotlinCompilerExtensionVersion "${Versions.compose}"
     }
 }
 

--- a/uicomponent-compose/main/build.gradle
+++ b/uicomponent-compose/main/build.gradle
@@ -1,4 +1,5 @@
 import io.github.droidkaigi.feeder.Dep
+import io.github.droidkaigi.feeder.Versions
 // TODO: make this library Kotlin MPP
 plugins {
     id 'com.android.library'
@@ -24,7 +25,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "${compose_version}"
+        kotlinCompilerExtensionVersion "${Versions.compose}"
     }
 }
 

--- a/uicomponent-compose/other/build.gradle
+++ b/uicomponent-compose/other/build.gradle
@@ -1,4 +1,5 @@
 import io.github.droidkaigi.feeder.Dep
+import io.github.droidkaigi.feeder.Versions
 // TODO: make this library Kotlin MPP
 plugins {
     id 'com.android.library'
@@ -22,7 +23,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "${compose_version}"
+        kotlinCompilerExtensionVersion "${Versions.compose}"
     }
 }
 


### PR DESCRIPTION
## Issue
- close #245

## Overview (Required)
- We can use Versions.compose for using places of compose_version

## Links
- https://github.com/DroidKaigi/conference-app-2021/blob/d0fdd62f14f833d413260ab5be8e316beeaaa841/build.gradle#L6
