### PR TITLE
Transition animation when switching tab content

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.feeder.feed
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -164,18 +165,20 @@ private fun FeedScreen(
                 AppBar(onNavigationIconClick, selectedTab, onSelectTab)
             },
             frontLayerContent = {
-                val isHome = selectedTab is FeedTabs.Home
-                FeedList(
-                    feedContents = if (selectedTab is FeedTabs.FilteredFeed) {
-                        feedContents.filterFeedType(selectedTab.feedItemClass)
-                    } else {
-                        feedContents
-                    },
-                    isHome = isHome,
-                    onClickFeed = onClickFeed,
-                    onFavoriteChange = onFavoriteChange,
-                    listState
-                )
+                Crossfade(targetState = selectedTab) { selectedTab ->
+                    val isHome = selectedTab is FeedTabs.Home
+                    FeedList(
+                        feedContents = if (selectedTab is FeedTabs.FilteredFeed) {
+                            feedContents.filterFeedType(selectedTab.feedItemClass)
+                        } else {
+                            feedContents
+                        },
+                        isHome = isHome,
+                        onClickFeed = onClickFeed,
+                        onFavoriteChange = onFavoriteChange,
+                        listState
+                    )
+                }
             }
         )
     }

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -50,7 +50,9 @@ fun AppContent(
     val deepLinkUri =
         "https://" + LocalContext.current.getString(R.string.deep_link_host) +
             LocalContext.current.getString(R.string.deep_link_path)
-    val actions = remember(navController, drawerContentState) { AppActions(navController, drawerContentState) }
+    val actions = remember(navController, drawerContentState) {
+        AppActions(navController, drawerContentState)
+    }
     ModalDrawer(
         modifier = modifier,
         drawerState = drawerState,
@@ -77,7 +79,8 @@ fun AppContent(
             ) { backStackEntry ->
                 val routePath = rememberRoutePath(
                     backStackEntry.arguments?.getString("feedTab")
-                        ?: FeedTabs.Home.routePath)
+                        ?: FeedTabs.Home.routePath
+                )
                 val selectedTab = FeedTabs.ofRoutePath(routePath.value)
                 actions.onSelectTab(selectedTab)
                 val context = LocalContext.current
@@ -104,7 +107,8 @@ fun AppContent(
             ) { backStackEntry ->
                 val routePath = rememberRoutePath(
                     backStackEntry.arguments?.getString("otherTab")
-                        ?: OtherTabs.AboutThisApp.routePath)
+                        ?: OtherTabs.AboutThisApp.routePath
+                )
                 val selectedTab = OtherTabs.ofRoutePath(routePath.value)
                 actions.onSelectOtherTab(selectedTab)
                 OtherScreen(

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -50,7 +50,7 @@ fun AppContent(
     val deepLinkUri =
         "https://" + LocalContext.current.getString(R.string.deep_link_host) +
             LocalContext.current.getString(R.string.deep_link_path)
-    val actions = remember(navController, drawerContentState) {
+    val actions = remember(navController) {
         AppActions(navController)
     }
     ModalDrawer(

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -58,9 +58,9 @@ fun AppContent(
         drawerState = drawerState,
         drawerShape = MaterialTheme.shapes.large.copy(all = CornerSize(0.dp)),
         drawerContent = {
-            DrawerContent(drawerContentState.currentValue) { route ->
-                if (drawerContentState.selectDrawerContent(route)) {
-                    actions.onSelectDrawerItem(route)
+            DrawerContent(drawerContentState.currentValue) { contents ->
+                if (drawerContentState.selectDrawerContent(contents.route)) {
+                    actions.onSelectDrawerItem(contents)
                 }
                 coroutineScope.launch {
                     drawerState.close()
@@ -127,8 +127,19 @@ fun AppContent(
 }
 
 private class AppActions(navController: NavHostController) {
-    val onSelectDrawerItem: (String) -> Unit = { route ->
-        navController.navigate(route)
+    val onSelectDrawerItem: (DrawerContents) -> Unit = { contents ->
+        navController.navigate(contents.route) {
+            popUpTo(navController.graph.startDestination) {
+                inclusive = when (contents) {
+                    DrawerContents.HOME,
+                    DrawerContents.BLOG,
+                    DrawerContents.VIDEO,
+                    DrawerContents.PODCAST,
+                    -> true
+                    else -> false
+                }
+            }
+        }
     }
 
     val onSelectFeed: (Context, FeedItem) -> Unit = { context, feedItem ->

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -129,6 +129,11 @@ fun AppContent(
 private class AppActions(navController: NavHostController) {
     val onSelectDrawerItem: (DrawerContents) -> Unit = { contents ->
         navController.navigate(contents.route) {
+            // Pop up to the start destination of the graph to
+            // avoid building up a large stack of destinations
+            // on the back stack as users select items.
+            // And clean up all of the stacks if users select one of feed tabs.
+            // Refer to https://developer.android.com/jetpack/compose/navigation#bottom-nav
             popUpTo(navController.graph.startDestination) {
                 inclusive = when (contents) {
                     DrawerContents.HOME,

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -90,6 +90,7 @@ fun AppContent(
                     onNavigationIconClick = onNavigationIconClick,
                     selectedTab = selectedTab,
                     onSelectedTab = { feedTabs ->
+                        // We don't use navigation component transitions here for animation.
                         routePath.value = feedTabs.routePath
                         drawerContentState.onSelectDrawerContent(feedTabs)
                     },
@@ -116,6 +117,7 @@ fun AppContent(
                 OtherScreen(
                     selectedTab = selectedTab,
                     onSelectTab = { otherTabs ->
+                        // We don't use navigation component transitions here for animation.
                         routePath.value = otherTabs.routePath
                         drawerContentState.onSelectDrawerContent(otherTabs)
                     },

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
@@ -17,6 +17,11 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -87,6 +92,34 @@ enum class DrawerContents(
 
     enum class Group {
         NEWS, OTHER;
+    }
+}
+
+class DrawerContentState(
+    initialValue: String,
+) {
+    var currentValue: String by mutableStateOf(initialValue)
+        private set
+
+    fun onSelectDrawerContent(route: String) {
+        currentValue = route
+    }
+
+    companion object {
+
+        fun Saver() = Saver<DrawerContentState, String>(
+            save = { it.currentValue },
+            restore = { DrawerContentState(it) }
+        )
+    }
+}
+
+@Composable
+fun rememberDrawerContentState(
+    initialValue: String
+): DrawerContentState {
+    return rememberSaveable(saver = DrawerContentState.Saver()) {
+        DrawerContentState(initialValue)
     }
 }
 

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
@@ -137,7 +137,7 @@ fun rememberDrawerContentState(initialValue: String): DrawerContentState {
 @Composable
 fun DrawerContent(
     currentRoute: String = DrawerContents.HOME.route,
-    onNavigate: (route: String) -> Unit,
+    onNavigate: (contents: DrawerContents) -> Unit,
 ) {
     Column {
         Spacer(modifier = Modifier.height(52.dp))
@@ -188,7 +188,7 @@ fun DrawerContent(
 private fun DrawerContentGroup(
     groupContents: List<DrawerContents>,
     currentRoute: String,
-    onNavigate: (route: String) -> Unit,
+    onNavigate: (contents: DrawerContents) -> Unit,
 ) {
     for (content in groupContents) {
         DrawerButton(
@@ -196,7 +196,7 @@ private fun DrawerContentGroup(
             label = content.label,
             isSelected = content.route == currentRoute,
             {
-                onNavigate(content.route)
+                onNavigate(content)
             }
         )
     }

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
@@ -101,8 +101,21 @@ class DrawerContentState(
     var currentValue: String by mutableStateOf(initialValue)
         private set
 
-    fun onSelectDrawerContent(route: String) {
-        currentValue = route
+    fun selectDrawerContent(route: String): Boolean {
+        return if (currentValue != route) {
+            currentValue = route
+            true
+        } else {
+            false
+        }
+    }
+
+    fun onSelectDrawerContent(feedTabs: FeedTabs) {
+        selectDrawerContent("feed/${feedTabs.routePath}")
+    }
+
+    fun onSelectDrawerContent(otherTabs: OtherTabs) {
+        selectDrawerContent("other/${otherTabs.routePath}")
     }
 
     companion object {
@@ -115,9 +128,7 @@ class DrawerContentState(
 }
 
 @Composable
-fun rememberDrawerContentState(
-    initialValue: String
-): DrawerContentState {
+fun rememberDrawerContentState(initialValue: String): DrawerContentState {
     return rememberSaveable(saver = DrawerContentState.Saver()) {
         DrawerContentState(initialValue)
     }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.feeder.other
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -95,32 +96,8 @@ fun OtherScreen(
                     color = MaterialTheme.colors.background,
                     modifier = Modifier.fillMaxHeight()
                 ) {
-                    when (selectedTab) {
-                        OtherTabs.AboutThisApp -> AboutThisApp()
-                        OtherTabs.Staff -> StaffList()
-                        else -> {
-                            val context = LocalContext.current
-                            Text(
-                                text = "Not implemented yet. Please create this screen!",
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(top = 32.dp)
-                                    .clickable {
-                                        val issue =
-                                            "https://github.com/DroidKaigi/" +
-                                                "conference-app-2021/issues" +
-                                                "?q=is%3Aissue+is%3Aopen+label%3Awelcome_contribute"
-                                        context.startActivity(
-                                            Intent(
-                                                Intent.ACTION_VIEW,
-                                                Uri.parse(
-                                                    issue
-                                                )
-                                            )
-                                        )
-                                    }
-                            )
-                        }
+                    Crossfade(targetState = selectedTab) { selectedTab ->
+                        Content(selectedTab)
                     }
                 }
             }
@@ -171,6 +148,39 @@ private fun AppBar(
                     )
                 },
                 onClick = { onSelectTab(tab) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun Content(
+    selectedTab: OtherTabs
+) {
+    when (selectedTab) {
+        OtherTabs.AboutThisApp -> AboutThisApp()
+        OtherTabs.Staff -> StaffList()
+        else -> {
+            val context = LocalContext.current
+            Text(
+                text = "Not implemented yet. Please create this screen!",
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 32.dp)
+                    .clickable {
+                        val issue =
+                            "https://github.com/DroidKaigi/" +
+                                "conference-app-2021/issues" +
+                                "?q=is%3Aissue+is%3Aopen+label%3Awelcome_contribute"
+                        context.startActivity(
+                            Intent(
+                                Intent.ACTION_VIEW,
+                                Uri.parse(
+                                    issue
+                                )
+                            )
+                        )
+                    }
             )
         }
     }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
@@ -97,7 +97,7 @@ fun OtherScreen(
                     modifier = Modifier.fillMaxHeight()
                 ) {
                     Crossfade(targetState = selectedTab) { selectedTab ->
-                        Content(selectedTab)
+                        BackdropFrontLayerContent(selectedTab)
                     }
                 }
             }
@@ -154,8 +154,8 @@ private fun AppBar(
 }
 
 @Composable
-private fun Content(
-    selectedTab: OtherTabs
+private fun BackdropFrontLayerContent(
+    selectedTab: OtherTabs,
 ) {
     when (selectedTab) {
         OtherTabs.AboutThisApp -> AboutThisApp()


### PR DESCRIPTION
## Issue
- close #79

## Overview (Required)
- Unfortunately, `navigation-compose` does not supports transition animation between `composable`s.
- To achieve transition animation between tab contents, 
   we should NOT navigate new `composable` when tab is selected.
   Instead, we need to update `selectedTab` state inside the current `FeedScreen`/`OtherScreen` on each events.
- material motion was not implemented in `material-compose`.
   So use `Crossfade` instead.
- :new: Add `DrawerContentState`, `rememberRoutePath()` to fix issues commented on https://github.com/DroidKaigi/conference-app-2021/pull/251#issuecomment-789305708.

## Links
- ~~https://issuetracker.google.com/issues/172112072~~
   <img width="481"  src="https://user-images.githubusercontent.com/3405740/109684942-1d480e00-7bc4-11eb-90cd-97c375d78681.png">
- https://developer.android.com/jetpack/compose/animation#crossfade

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3405740/109815540-1a582680-7c73-11eb-98c7-2cf0bdd61ef0.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/109815527-15937280-7c73-11eb-88d6-749f6364483e.gif" width="300" />
