### PR TITLE
Setup Flipper

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -142,6 +142,7 @@ dependencies {
     implementation Dep.Arbor.android
 
     debugImplementation Dep.Flipper.flipper
+    debugImplementation Dep.Flipper.networkPlugin
     debugImplementation Dep.Flipper.soLoader
 
     testImplementation 'junit:junit:4.13.1'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -141,6 +141,9 @@ dependencies {
     implementation Dep.Arbor.jvm
     implementation Dep.Arbor.android
 
+    debugImplementation Dep.Flipper.flipper
+    debugImplementation Dep.Flipper.soLoader
+
     testImplementation 'junit:junit:4.13.1'
     testImplementation Dep.Coroutines.test
     testImplementation 'io.kotest:kotest-assertions-core:4.3.2'

--- a/android/src/debug/AndroidManifest.xml
+++ b/android/src/debug/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application tools:ignore="AllowBackup,MissingApplicationIcon">
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="io.github.droidkaigi.feeder.FlipperInitializer"
+                android:value="androidx.startup" />
+        </provider>
+    </application>
+
+</manifest>

--- a/android/src/debug/java/io/github/droidkaigi/feeder/FlipperInitializer.kt
+++ b/android/src/debug/java/io/github/droidkaigi/feeder/FlipperInitializer.kt
@@ -4,15 +4,22 @@ import android.content.Context
 import androidx.startup.Initializer
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.soloader.SoLoader
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 
 @Suppress("unused")
 class FlipperInitializer : Initializer<Unit> {
     override fun create(context: Context) {
+        val hilt = EntryPointAccessors.fromApplication(context, HiltEntryPoint::class.java)
         SoLoader.init(context, false)
         AndroidFlipperClient.getInstance(context).apply {
             addPlugin(DatabasesFlipperPlugin(context))
+            addPlugin(hilt.networkFlipperPlugin())
             addPlugin(SharedPreferencesFlipperPlugin(context))
             start()
         }
@@ -20,5 +27,11 @@ class FlipperInitializer : Initializer<Unit> {
 
     override fun dependencies(): List<Class<out Initializer<*>>> {
         return emptyList()
+    }
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface HiltEntryPoint {
+        fun networkFlipperPlugin(): NetworkFlipperPlugin
     }
 }

--- a/android/src/debug/java/io/github/droidkaigi/feeder/FlipperInitializer.kt
+++ b/android/src/debug/java/io/github/droidkaigi/feeder/FlipperInitializer.kt
@@ -1,0 +1,24 @@
+package io.github.droidkaigi.feeder
+
+import android.content.Context
+import androidx.startup.Initializer
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
+import com.facebook.soloader.SoLoader
+
+@Suppress("unused")
+class FlipperInitializer : Initializer<Unit> {
+    override fun create(context: Context) {
+        SoLoader.init(context, false)
+        AndroidFlipperClient.getInstance(context).apply {
+            addPlugin(DatabasesFlipperPlugin(context))
+            addPlugin(SharedPreferencesFlipperPlugin(context))
+            start()
+        }
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> {
+        return emptyList()
+    }
+}

--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -116,6 +116,7 @@ object Dep {
         //      We can upgrade it to newer version once following issue is resolved.
         //      https://github.com/facebook/flipper/issues/1968
         const val flipper = "com.facebook.flipper:flipper:0.76.0"
+        const val networkPlugin = "com.facebook.flipper:flipper-network-plugin:0.76.0"
         const val soLoader = "com.facebook.soloader:soloader:0.10.1"
     }
 }

--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -110,4 +110,12 @@ object Dep {
         const val jvm = "com.ToxicBakery.logging:arbor-jvm:1.35.72"
         const val android = "com.ToxicBakery.logging:arbor-android:1.35.72"
     }
+
+    object Flipper {
+        // TODO We use Flipper 0.76.0 for now because app crashes with 0.77.0 and 0.78.0.
+        //      We can upgrade it to newer version once following issue is resolved.
+        //      https://github.com/facebook/flipper/issues/1968
+        const val flipper = "com.facebook.flipper:flipper:0.76.0"
+        const val soLoader = "com.facebook.soloader:soloader:0.10.1"
+    }
 }

--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -78,6 +78,10 @@ kotlin {
 
             implementation Dep.Arbor.jvm
         }
+        androidDebug.dependencies {
+            implementation Dep.Flipper.flipper
+            implementation Dep.Flipper.networkPlugin
+        }
         androidTest.dependencies {
             implementation Dep.KotlinTest.junit
             implementation Dep.Kotlin.reflect

--- a/data/api/src/debug/java/io/github/droidkaigi/feeder/data/ApiDebugModule.kt
+++ b/data/api/src/debug/java/io/github/droidkaigi/feeder/data/ApiDebugModule.kt
@@ -1,0 +1,30 @@
+package io.github.droidkaigi.feeder.data
+
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import okhttp3.Interceptor
+
+@InstallIn(SingletonComponent::class)
+@Module
+class ApiDebugModule {
+    @Singleton
+    @Provides
+    internal fun provideNetworkFlipperPlugin(): NetworkFlipperPlugin {
+        return NetworkFlipperPlugin()
+    }
+
+    @Singleton
+    @Provides
+    internal fun provideOkHttpNetworkInterceptors(
+        networkFlipperPlugin: NetworkFlipperPlugin,
+    ): List<Interceptor> {
+        return listOf(
+            FlipperOkhttpInterceptor(networkFlipperPlugin),
+        )
+    }
+}

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/ApiModule.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/ApiModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.github.droidkaigi.feeder.data.response.InstantSerializer
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.features.defaultRequest
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
@@ -14,16 +15,25 @@ import io.ktor.client.features.logging.LogLevel
 import io.ktor.client.features.logging.Logger
 import io.ktor.client.features.logging.Logging
 import io.ktor.client.request.headers
+import javax.inject.Singleton
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
+import okhttp3.Interceptor
 
 @InstallIn(SingletonComponent::class)
 @Module
 class ApiModule {
+    @Singleton
     @Provides
-    internal fun provideHttpClient(userDataStore: UserDataStore): HttpClient {
-        return HttpClient {
+    internal fun provideHttpClient(
+        userDataStore: UserDataStore,
+        networkInterceptors: List<@JvmSuppressWildcards Interceptor>,
+    ): HttpClient {
+        return HttpClient(OkHttp) {
+            engine {
+                networkInterceptors.forEach { addNetworkInterceptor(it) }
+            }
             install(JsonFeature) {
                 serializer = KotlinxSerializer(
                     json = Json {
@@ -52,6 +62,7 @@ class ApiModule {
         }
     }
 
+    @Singleton
     @Provides
     internal fun provideFirebaseAuthApi(
         httpClient: HttpClient,

--- a/data/api/src/release/java/io/github/droidkaigi/feeder/data/ApiReleaseModule.kt
+++ b/data/api/src/release/java/io/github/droidkaigi/feeder/data/ApiReleaseModule.kt
@@ -1,0 +1,18 @@
+package io.github.droidkaigi.feeder.data
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import okhttp3.Interceptor
+
+@InstallIn(SingletonComponent::class)
+@Module
+class ApiReleaseModule {
+    @Singleton
+    @Provides
+    internal fun provideOkHttpNetworkInterceptors(): List<Interceptor> {
+        return listOf()
+    }
+}


### PR DESCRIPTION
## Issue

- close #91

## Overview (Required)

- Integrated [Flipper](https://fbflipper.com/) for debugging app
- Set up following plugins
  - [Network](https://fbflipper.com/docs/setup/network-plugin)
  - [SharedPreferences](https://fbflipper.com/docs/setup/shared-preferences-plugin)
  - [Databases](https://fbflipper.com/docs/setup/databases-plugin)

## Implementation notes

- Set up Flipper 0.76.0 although its latest is 0.78.0. App crashed when I tried Flipper 0.77.0 and 0.78.0 because of https://github.com/facebook/flipper/issues/1968. We should keep using 0.76.0 until the issue is resolved
- Added Flipper dependencies only in `debug` source set without using its "no-op" package to follow [Flipper's recommendation](https://github.com/facebook/flipper/issues/1968)
  > Please note that our `flipper-noop` package provides a limited subset of the APIs provided by the `flipper` package and does not provide any plugin stubs. It is recommended that you keep all Flipper instantiation code in a separate build variant to ensure it doesn't accidentally make it into your production builds.
- OkHttp was implicitly used as the engine of Ktor (selected automatically by `ServiceLoader`) even before this PR. I explicitly specify it when configuring `HttpClient` to set `FlipperOkhttpInterceptor` to `OkHttpClient`
- I added `@Singleton` annotation to the functions of `ApiModule` to make sure that `HttpClient` is created only once. According to the 2nd example of [component scopes](https://developer.android.com/training/dependency-injection/hilt-android#component-scopes) document, it seem necessary to add `@Singleton` annotation to the functions. Actually I found `HttpClient` was instantiated twice without this annotation

## Screenshot

https://user-images.githubusercontent.com/12084705/109826908-9efc7200-7c7e-11eb-8eb4-4ee5aef0cf50.mov