### PR TITLE
fix dependencies arbor

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -138,8 +138,7 @@ dependencies {
     debugImplementation Dep.Compose.tooling
     debugImplementation Dep.Kotlin.reflect
 
-    implementation Dep.Arbor.jvm
-    implementation Dep.Arbor.android
+    implementation Dep.Arbor.common
 
     debugImplementation Dep.Flipper.flipper
     debugImplementation Dep.Flipper.networkPlugin

--- a/android/src/main/java/io/github/droidkaigi/feeder/ArborInitializer.kt
+++ b/android/src/main/java/io/github/droidkaigi/feeder/ArborInitializer.kt
@@ -3,11 +3,11 @@ package io.github.droidkaigi.feeder
 import android.content.Context
 import androidx.startup.Initializer
 import com.toxicbakery.logging.Arbor
-import com.toxicbakery.logging.LogCatSeedling
+import com.toxicbakery.logging.Seedling
 
 class ArborInitializer : Initializer<Unit> {
     override fun create(context: Context) {
-        Arbor.sow(LogCatSeedling())
+        Arbor.sow(Seedling())
     }
 
     override fun dependencies(): List<Class<out Initializer<*>>> {

--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -107,8 +107,7 @@ object Dep {
     }
 
     object Arbor {
-        const val jvm = "com.ToxicBakery.logging:arbor-jvm:1.35.72"
-        const val android = "com.ToxicBakery.logging:arbor-android:1.35.72"
+        const val common = "com.ToxicBakery.logging:common:1.35.72"
     }
 
     object Flipper {

--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -51,7 +51,7 @@ kotlin {
 
             implementation(Dep.firebaseAuth)
 
-            implementation Dep.Arbor.jvm
+            implementation Dep.Arbor.common
         }
         commonTest.dependencies {
             implementation Dep.KotlinTest.common
@@ -76,7 +76,7 @@ kotlin {
 //            testImplementation "com.google.dagger:hilt-android-testing:2.31.2-alpha"
 //            kaptTest Dep.Dagger.hiltAndroidCompiler
 
-            implementation Dep.Arbor.jvm
+            implementation Dep.Arbor.common
         }
         androidDebug.dependencies {
             implementation Dep.Flipper.flipper


### PR DESCRIPTION
## Issue
- close #228 

## Overview (Required)
- Fixed dependencies
  - delete ```com.ToxicBakery.logging:arbor-android``` and ```com.ToxicBakery.logging:arbor-jvm``` dependency
  - use ```com.ToxicBakery.logging:common```
- Fixed import that cannot be referenced due to changes
  - delete ```import com.toxicbakery.logging.LogCatSeedling``` (Cannot be referenced)
  - add ```import com.toxicbakery.logging.Seedling```
