### PR TITLE
Delete an outdated comment in LoadingScreen.kt

### DIFF
--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/LandingScreen.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/LandingScreen.kt
@@ -16,7 +16,6 @@ private const val SplashWaitTime: Long = 2000
 @Composable
 fun LandingScreen(modifier: Modifier = Modifier, onTimeout: () -> Unit) {
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        // FIXME Deprecated
         LaunchedEffect(Unit) {
             delay(SplashWaitTime)
             onTimeout()


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2021/issues/248

## Overview (Required)
- As described in this PR title, I deleted an outdated comment in LoadingScreen.kt

## Links
-

## Screenshot
no diff