### PR TITLE
Fade through animation when switching tab content

### DIFF
--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -16,6 +16,7 @@ object Dep {
         const val layout = "androidx.compose.foundation:foundation-layout:${Versions.compose}"
         const val ui = "androidx.compose.ui:ui:${Versions.compose}"
         const val tooling = "androidx.compose.ui:ui-tooling:${Versions.compose}"
+        const val util = "androidx.compose.ui:ui-util:${Versions.compose}"
         const val material = "androidx.compose.material:material:${Versions.compose}1"
         const val iconsExtended =
             "androidx.compose.material:material-icons-extended:${Versions.compose}"

--- a/uicomponent-compose/core/build.gradle
+++ b/uicomponent-compose/core/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation Dep.Compose.layout
     implementation Dep.Compose.ui
     implementation Dep.Compose.tooling
+    implementation Dep.Compose.util
     implementation Dep.Compose.material
     implementation Dep.Compose.iconsExtended
     implementation Dep.Compose.animation

--- a/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/animation/FadeThrough.kt
+++ b/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/animation/FadeThrough.kt
@@ -97,9 +97,10 @@ fun <T> FadeThrough(
                         }
                     }
                 ) { if (it == key) 1f else DEFAULT_START_SCALE }
-                Box(Modifier
-                    .alpha(alpha = alpha)
-                    .scale(scale = scale)
+                Box(
+                    Modifier
+                        .alpha(alpha = alpha)
+                        .scale(scale = scale)
                 ) {
                     content(key)
                 }

--- a/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/animation/FadeThrough.kt
+++ b/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/animation/FadeThrough.kt
@@ -1,0 +1,125 @@
+package io.github.droidkaigi.feeder.core.animation
+
+import androidx.compose.animation.core.AnimationConstants.DefaultDurationMillis
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.util.fastForEach
+
+private const val DEFAULT_START_SCALE = 0.92f
+private const val PROGRESS_THRESHOLD = 0.35f
+
+/**
+ * [FadeThrough] allows to switch between two layouts with a fade through animation.
+ *
+ * @see com.google.android.material.transition.MaterialFadeThrough
+ * @see androidx.compose.animation.Crossfade
+ *
+ * @param targetState is a key representing your target layout state. Every time you change a key
+ * the animation will be triggered. The [content] called with the old key will be faded out while
+ * the [content] called with the new key will be faded in.
+ * @param modifier Modifier to be applied to the animation container.
+ * @param durationMillis total duration of the animation.
+ * @param delayMillis the amount of time in milliseconds that animation waits before starting.
+ * @param easing the easing curve that will be used to interpolate between start and end.
+ */
+@Composable
+fun <T> FadeThrough(
+    targetState: T,
+    modifier: Modifier = Modifier,
+    durationMillis: Int = DefaultDurationMillis,
+    delayMillis: Int = 0,
+    easing: Easing = FastOutSlowInEasing,
+    content: @Composable (T) -> Unit,
+) {
+    val items = remember { mutableStateListOf<FadeThroughAnimationItem<T>>() }
+    val transitionState = remember { MutableTransitionState(targetState) }
+    val targetChanged = (targetState != transitionState.targetState)
+    transitionState.targetState = targetState
+    val transition = updateTransition(transitionState)
+    if (targetChanged || items.isEmpty()) {
+        // Only manipulate the list when the state is changed, or in the first run.
+        val keys = items.map { it.key }.run {
+            if (!contains(targetState)) {
+                toMutableList().also { it.add(targetState) }
+            } else {
+                this
+            }
+        }
+        items.clear()
+        keys.mapTo(items) { key ->
+            val outgoingDurationMillis = (durationMillis * PROGRESS_THRESHOLD).toInt()
+            val incomingDurationMillis = durationMillis - outgoingDurationMillis
+            FadeThroughAnimationItem(key) {
+                val alpha by transition.animateFloat(
+                    transitionSpec = {
+                        if (targetState == key) {
+                            tween(
+                                durationMillis = incomingDurationMillis,
+                                delayMillis = delayMillis + outgoingDurationMillis,
+                                easing = easing
+                            )
+                        } else {
+                            tween(
+                                durationMillis = outgoingDurationMillis,
+                                delayMillis = delayMillis,
+                                easing = easing
+                            )
+                        }
+                    }
+                ) { if (it == key) 1f else 0f }
+                val scale by transition.animateFloat(
+                    transitionSpec = {
+                        if (targetState == key) {
+                            tween(
+                                durationMillis = incomingDurationMillis,
+                                delayMillis = delayMillis + outgoingDurationMillis,
+                                easing = easing
+                            )
+                        } else {
+                            tween(
+                                durationMillis = outgoingDurationMillis,
+                                delayMillis = delayMillis,
+                                easing = easing
+                            )
+                        }
+                    }
+                ) { if (it == key) 1f else DEFAULT_START_SCALE }
+                Box(Modifier
+                    .alpha(alpha = alpha)
+                    .scale(scale = scale)
+                ) {
+                    content(key)
+                }
+            }
+        }
+    } else if (transitionState.currentState == transitionState.targetState) {
+        // Remove all the intermediate items from the list once the animation is finished.
+        items.removeAll { it.key != transitionState.targetState }
+    }
+
+    Box(modifier) {
+        items.fastForEach {
+            key(it.key) {
+                it.content()
+            }
+        }
+    }
+}
+
+private data class FadeThroughAnimationItem<T>(
+    val key: T,
+    val content: @Composable () -> Unit,
+)

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -43,8 +43,8 @@ import io.github.droidkaigi.feeder.core.getReadableMessage
 import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 import io.github.droidkaigi.feeder.core.use
 import io.github.droidkaigi.feeder.core.util.collectInLaunchedEffect
-import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
+import kotlinx.coroutines.launch
 
 sealed class FeedTabs(val name: String, val routePath: String) {
     object Home : FeedTabs("Home", "home")

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.feeder.feed
 
-import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -39,12 +38,13 @@ import dev.chrisbanes.accompanist.insets.toPaddingValues
 import io.github.droidkaigi.feeder.FeedContents
 import io.github.droidkaigi.feeder.FeedItem
 import io.github.droidkaigi.feeder.Filters
+import io.github.droidkaigi.feeder.core.animation.FadeThrough
 import io.github.droidkaigi.feeder.core.getReadableMessage
 import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 import io.github.droidkaigi.feeder.core.use
 import io.github.droidkaigi.feeder.core.util.collectInLaunchedEffect
-import kotlin.reflect.KClass
 import kotlinx.coroutines.launch
+import kotlin.reflect.KClass
 
 sealed class FeedTabs(val name: String, val routePath: String) {
     object Home : FeedTabs("Home", "home")
@@ -166,7 +166,7 @@ private fun FeedScreen(
                 AppBar(onNavigationIconClick, selectedTab, onSelectTab)
             },
             frontLayerContent = {
-                Crossfade(targetState = selectedTab) { selectedTab ->
+                FadeThrough(targetState = selectedTab) { selectedTab ->
                     val isHome = selectedTab is FeedTabs.Home
                     FeedList(
                         feedContents = if (selectedTab is FeedTabs.FilteredFeed) {

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
@@ -2,7 +2,6 @@ package io.github.droidkaigi.feeder.other
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -35,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import dev.chrisbanes.accompanist.insets.LocalWindowInsets
 import dev.chrisbanes.accompanist.insets.statusBarsPadding
 import io.github.droidkaigi.feeder.about.AboutThisApp
+import io.github.droidkaigi.feeder.core.animation.FadeThrough
 import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 import io.github.droidkaigi.feeder.staff.StaffList
 
@@ -99,7 +99,7 @@ fun OtherScreen(
                     color = MaterialTheme.colors.background,
                     modifier = Modifier.fillMaxHeight()
                 ) {
-                    Crossfade(targetState = selectedTab) { selectedTab ->
+                    FadeThrough(targetState = selectedTab) { selectedTab ->
                         BackdropFrontLayerContent(selectedTab)
                     }
                 }


### PR DESCRIPTION
## Issue
- close #253

## Overview (Required)
- Implements `FadeThrough` to improve tab switching animation.
- To use `fastForEach`, add `androidx.compose.ui:ui-util` dependency.

## Links
- https://material.io/design/motion/the-motion-system.html#fade-through
- https://developer.android.com/jetpack/compose/animation#updateTransition

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3405740/110163723-c3e61600-7e33-11eb-9260-1899a1c85a6b.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/110163708-bf216200-7e33-11eb-9814-596fda912b18.gif" width="300" />
