### PR TITLE
Add app theme function with background for Preview

### DIFF
--- a/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/theme/Theme.kt
+++ b/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/theme/Theme.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.feeder.core.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
@@ -23,7 +24,7 @@ private val LightColorPalette = lightColors(
 fun ConferenceAppFeederTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable
-    () -> Unit,
+        () -> Unit,
 ) {
     val colors = if (darkTheme) {
         DarkColorPalette
@@ -37,5 +38,16 @@ fun ConferenceAppFeederTheme(
             shapes = shapes,
             content = content
         )
+    }
+}
+
+@Composable
+fun AppThemeWithBackground(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable
+        () -> Unit,
+) {
+    Surface {
+        ConferenceAppFeederTheme(darkTheme, content)
     }
 }

--- a/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/theme/Theme.kt
+++ b/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/theme/Theme.kt
@@ -24,7 +24,7 @@ private val LightColorPalette = lightColors(
 fun ConferenceAppFeederTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable
-        () -> Unit,
+    () -> Unit,
 ) {
     val colors = if (darkTheme) {
         DarkColorPalette
@@ -45,7 +45,7 @@ fun ConferenceAppFeederTheme(
 fun AppThemeWithBackground(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable
-        () -> Unit,
+    () -> Unit,
 ) {
     Surface {
         ConferenceAppFeederTheme(darkTheme, content)

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,7 +27,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
+import io.github.droidkaigi.feeder.core.theme.AppThemeWithBackground
 import io.github.droidkaigi.feeder.feed.FeedTabs
 import io.github.droidkaigi.feeder.main.R
 import io.github.droidkaigi.feeder.other.OtherTabs
@@ -205,10 +204,8 @@ private fun DrawerContentGroup(
 @Preview
 @Composable
 fun PreviewDrawerContent() {
-    ConferenceAppFeederTheme {
-        Surface {
-            DrawerContent(currentRoute = DrawerContents.HOME.route) {
-            }
+    AppThemeWithBackground {
+        DrawerContent(currentRoute = DrawerContents.HOME.route) {
         }
     }
 }


### PR DESCRIPTION
## Overview (Required)
- Currently, there are many previews that are difficult to see because the background cannot be displayed in Preview, so I added a function to fix it.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
