### PR TITLE
Implement getDefaultLocale for iOS

### DIFF
--- a/model/src/iosMain/kotlin/io/github/droidkaigi/feeder/Locale.kt
+++ b/model/src/iosMain/kotlin/io/github/droidkaigi/feeder/Locale.kt
@@ -1,0 +1,12 @@
+package io.github.droidkaigi.feeder
+
+import platform.Foundation.NSLocale
+import platform.Foundation.countryCode
+import platform.Foundation.currentLocale
+
+actual fun getDefaultLocale(): Locale =
+    if (NSLocale.currentLocale.countryCode == "JP") {
+        Locale.JAPAN
+    } else {
+        Locale.OTHER
+    }


### PR DESCRIPTION
## Issue
- close #272 

## Overview (Required)
- Determine `Locale` by current `countryCode`.

## Links
- https://developer.apple.com/documentation/foundation/nslocale/1409990-currentlocale?language=objc
- https://developer.apple.com/documentation/foundation/nslocale/1643060-countrycode?language=objc
