### PR TITLE
Transit to chrome custom tab using navigation component

### DIFF
--- a/uicomponent-compose/core/build.gradle
+++ b/uicomponent-compose/core/build.gradle
@@ -62,4 +62,6 @@ dependencies {
 
     // Android
     implementation Dep.Jetpack.browser
+
+    implementation Dep.Arbor.common
 }

--- a/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/navigation/ChromeCustomTabsNavigator.kt
+++ b/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/navigation/ChromeCustomTabsNavigator.kt
@@ -1,0 +1,59 @@
+package io.github.droidkaigi.feeder.core.navigation
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import android.util.Patterns
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import com.toxicbakery.logging.Arbor
+
+@Navigator.Name("chrome")
+class ChromeCustomTabsNavigator(private val context: Context) :
+    Navigator<ChromeCustomTabsNavigator.Destination>() {
+
+    override fun navigate(
+        destination: Destination,
+        args: Bundle?,
+        navOptions: NavOptions?,
+        navigatorExtras: Extras?,
+    ): NavDestination? {
+        val url = args?.getString(ARGUMENT_NAME_URL)
+            ?: throw IllegalStateException("Destination ${destination.id} does not have an url.")
+
+        if (url.isInvalidWebUrl()) {
+            throw IllegalArgumentException("Url($url) is a invalid web URL.")
+        }
+
+        val builder = CustomTabsIntent.Builder()
+            .setShowTitle(true)
+            .setUrlBarHidingEnabled(true)
+
+        val intent = builder.build()
+        try {
+            intent.launchUrl(context, Uri.parse(url))
+        } catch (e: ActivityNotFoundException) {
+            Arbor.d(e, "Fail ChromeCustomTabsNavigator. launchUrl($url)")
+        }
+        return null // Do not add to the back stack, managed by Chrome Custom Tabs
+    }
+
+    private fun String.isInvalidWebUrl(): Boolean {
+        return Patterns.WEB_URL.matcher(this).matches().not()
+    }
+
+    override fun createDestination() = Destination(this)
+
+    override fun popBackStack() = true // Managed by Chrome Custom Tabs
+
+    @NavDestination.ClassType(Activity::class)
+    class Destination(navigator: Navigator<out NavDestination>) : NavDestination(navigator)
+
+    companion object {
+        const val ARGUMENT_NAME_URL: String = "url"
+    }
+}

--- a/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/navigation/NavGraphBuilder.kt
+++ b/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/navigation/NavGraphBuilder.kt
@@ -1,0 +1,27 @@
+package io.github.droidkaigi.feeder.core.navigation
+
+import androidx.navigation.NavArgument
+import androidx.navigation.NavArgumentBuilder
+import androidx.navigation.NavDestinationDsl
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.get
+import io.github.droidkaigi.feeder.core.navigation.ChromeCustomTabsNavigator.Companion.ARGUMENT_NAME_URL
+
+fun NavGraphBuilder.chromeCustomTabs() {
+    addDestination(
+        ChromeCustomTabsNavigator.Destination(provider[ChromeCustomTabsNavigator::class]).apply {
+            val route = "chrome/{$ARGUMENT_NAME_URL}"
+            val internalRoute = createRoute(route)
+            addDeepLink(internalRoute)
+            addArgument(KEY_ROUTE, navArgument { defaultValue = route })
+            id = internalRoute.hashCode()
+            addArgument(ARGUMENT_NAME_URL, navArgument { type = NavType.StringType })
+        }
+    )
+}
+
+@NavDestinationDsl
+inline fun navArgument(builder: NavArgumentBuilder.() -> Unit): NavArgument {
+    return NavArgumentBuilder().apply(builder).build()
+}

--- a/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/navigation/NavHostController.kt
+++ b/uicomponent-compose/core/src/main/java/io/github/droidkaigi/feeder/core/navigation/NavHostController.kt
@@ -1,0 +1,50 @@
+package io.github.droidkaigi.feeder.core.navigation
+
+import android.content.Context
+import android.os.Bundle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.net.toUri
+import androidx.navigation.NavController
+import androidx.navigation.NavDeepLinkRequest
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptionsBuilder
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.navOptions
+
+internal const val KEY_ROUTE = "android-support-nav:controller:chrome"
+
+@Composable
+public fun rememberCustomNavController(): NavHostController {
+    val context = LocalContext.current
+    return rememberSaveable(saver = CustomNavControllerSaver(context)) {
+        createCustomNavController(context)
+    }
+}
+
+private fun createCustomNavController(context: Context) =
+    NavHostController(context).apply {
+        navigatorProvider.addNavigator(ChromeCustomTabsNavigator(context))
+        navigatorProvider.addNavigator(ComposeNavigator())
+    }
+
+private fun CustomNavControllerSaver(
+    context: Context,
+): Saver<NavHostController, *> = Saver<NavHostController, Bundle>(
+    save = { it.saveState() },
+    restore = { createCustomNavController(context).apply { restoreState(it) } }
+)
+
+fun NavController.navigateChromeCustomTabs(
+    url: String,
+    builder: NavOptionsBuilder.() -> Unit = {},
+) {
+    navigate(
+        NavDeepLinkRequest.Builder.fromUri(createRoute("chrome/$url").toUri()).build(),
+        navOptions(builder)
+    )
+}
+
+internal fun createRoute(route: String) = "android-app://androidx.navigation.chrome/$route"

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -1,8 +1,5 @@
 package io.github.droidkaigi.feeder
 
-import android.content.Context
-import android.net.Uri
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material.DrawerDefaults
 import androidx.compose.material.DrawerValue
@@ -24,8 +21,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navArgument
 import androidx.navigation.compose.navigate
-import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navDeepLink
+import io.github.droidkaigi.feeder.core.navigation.chromeCustomTabs
+import io.github.droidkaigi.feeder.core.navigation.navigateChromeCustomTabs
+import io.github.droidkaigi.feeder.core.navigation.rememberCustomNavController
 import io.github.droidkaigi.feeder.feed.FeedScreen
 import io.github.droidkaigi.feeder.feed.FeedTabs
 import io.github.droidkaigi.feeder.main.R
@@ -40,7 +39,7 @@ fun AppContent(
 ) {
     val drawerState = rememberDrawerState(firstDrawerValue)
     val drawerContentState = rememberDrawerContentState(DrawerContents.HOME.route)
-    val navController = rememberNavController()
+    val navController = rememberCustomNavController()
     val coroutineScope = rememberCoroutineScope()
     val onNavigationIconClick: () -> Unit = {
         coroutineScope.launch {
@@ -85,7 +84,6 @@ fun AppContent(
                 )
                 val selectedTab = FeedTabs.ofRoutePath(routePath.value)
                 drawerContentState.onSelectDrawerContent(selectedTab)
-                val context = LocalContext.current
                 FeedScreen(
                     onNavigationIconClick = onNavigationIconClick,
                     selectedTab = selectedTab,
@@ -95,7 +93,7 @@ fun AppContent(
                         drawerContentState.onSelectDrawerContent(feedTabs)
                     },
                     onDetailClick = { feedItem: FeedItem ->
-                        actions.onSelectFeed(context, feedItem)
+                        actions.showChromeCustomTabs(feedItem.link)
                     }
                 )
             }
@@ -124,6 +122,7 @@ fun AppContent(
                     onNavigationIconClick = onNavigationIconClick
                 )
             }
+            chromeCustomTabs()
         }
     }
 }
@@ -149,13 +148,8 @@ private class AppActions(navController: NavHostController) {
         }
     }
 
-    val onSelectFeed: (Context, FeedItem) -> Unit = { context, feedItem ->
-        val builder = CustomTabsIntent.Builder()
-            .setShowTitle(true)
-            .setUrlBarHidingEnabled(true)
-
-        val intent = builder.build()
-        intent.launchUrl(context, Uri.parse(feedItem.link))
+    val showChromeCustomTabs: (String) -> Unit = { link ->
+        navController.navigateChromeCustomTabs(link)
     }
 }
 


### PR DESCRIPTION
## Issue
- close #77

## Overview (Required)
- Add `ChromeCustomTabsNavigator`
- and extension functions to handle chrome custom tabs in navigation component.
   - `rememberCustomNavController()`
   - `chromeCustomTabs()`
   - `navigateChromeCustomTabs(url: String)`

## Note
- Currently, the following error occurs.
   ```
   E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.github.droidkaigi.feeder.debug, PID: 8675
    java.lang.RuntimeException:
       Parcel: unable to marshal value androidx.compose.runtime.SnapshotMutableStateImpl@45a6df9
   ```
   The fix will be released in beta02.
   https://issuetracker.google.com/issues/180042685

## Links
- https://proandroiddev.com/add-chrome-custom-tabs-to-the-android-navigation-component-75092ce20c6a
- https://github.com/DroidKaigi/conference-app-2020/pull/342

## Screenshot

https://user-images.githubusercontent.com/3405740/110198459-00e2f480-7e96-11eb-8b1d-996e379558a5.mp4

