### PR TITLE
Use material icon for navigation drawer image

### DIFF
--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
@@ -43,19 +43,19 @@ enum class DrawerContents(
     ),
     BLOG(
         group = Group.NEWS,
-        imageResId = R.drawable.ic_baseline_list_alt_24,
+        imageResId = R.drawable.ic_baseline_text_snippet_24,
         label = "BLOG",
         route = "feed/${FeedTabs.FilteredFeed.Blog.routePath}"
     ),
     VIDEO(
         group = Group.NEWS,
-        imageResId = R.drawable.ic_baseline_list_alt_24,
+        imageResId = R.drawable.ic_baseline_videocam_24,
         label = "VIDEO",
         route = "feed/${FeedTabs.FilteredFeed.Video.routePath}"
     ),
     PODCAST(
         group = Group.NEWS,
-        imageResId = R.drawable.ic_baseline_list_alt_24,
+        imageResId = R.drawable.ic_baseline_mic_none_24,
         label = "PODCAST",
         route = "feed/${FeedTabs.FilteredFeed.Podcast.routePath}"
     ),

--- a/uicomponent-compose/main/src/main/res/drawable/ic_baseline_mic_none_24.xml
+++ b/uicomponent-compose/main/src/main/res/drawable/ic_baseline_mic_none_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,14c1.66,0 2.99,-1.34 2.99,-3L15,5c0,-1.66 -1.34,-3 -3,-3S9,3.34 9,5v6c0,1.66 1.34,3 3,3zM10.8,4.9c0,-0.66 0.54,-1.2 1.2,-1.2 0.66,0 1.2,0.54 1.2,1.2l-0.01,6.2c0,0.66 -0.53,1.2 -1.19,1.2 -0.66,0 -1.2,-0.54 -1.2,-1.2L10.8,4.9zM17.3,11c0,3 -2.54,5.1 -5.3,5.1S6.7,14 6.7,11L5,11c0,3.41 2.72,6.23 6,6.72L11,21h2v-3.28c3.28,-0.48 6,-3.3 6,-6.72h-1.7z"/>
+</vector>

--- a/uicomponent-compose/main/src/main/res/drawable/ic_baseline_text_snippet_24.xml
+++ b/uicomponent-compose/main/src/main/res/drawable/ic_baseline_text_snippet_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20.41,8.41l-4.83,-4.83C15.21,3.21 14.7,3 14.17,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V9.83C21,9.3 20.79,8.79 20.41,8.41zM7,7h7v2H7V7zM17,17H7v-2h10V17zM17,13H7v-2h10V13z"/>
+</vector>

--- a/uicomponent-compose/main/src/main/res/drawable/ic_baseline_videocam_24.xml
+++ b/uicomponent-compose/main/src/main/res/drawable/ic_baseline_videocam_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17,10.5V7c0,-0.55 -0.45,-1 -1,-1H4c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h12c0.55,0 1,-0.45 1,-1v-3.5l4,4v-11l-4,4z"/>
+</vector>


### PR DESCRIPTION
## Issue
- close #237 

## Overview (Required)
- use material icon for navigation drawer image
  - BLOG -> text_snippet
  - VIDEO -> videocam
  - PODCAST -> mic_none 

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/48081026/110200310-9e432600-7ea0-11eb-91e9-f3e6a0830fee.png" width="300" /> | <img src="https://user-images.githubusercontent.com/48081026/110200419-51ac1a80-7ea1-11eb-859a-0dd54af0e490.png" width="300" />
