### PR TITLE
Show background for AnswerSurveyItem Preview

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AnswerSurveyItem.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AnswerSurveyItem.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import io.github.droidkaigi.feeder.core.NetworkImage
-import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
+import io.github.droidkaigi.feeder.core.theme.AppThemeWithBackground
 
 @Composable
 fun AnswerSurveyItem(
@@ -98,7 +98,7 @@ fun AnswerSurveyItem(
 @Preview
 @Composable
 fun AnswerSurveyItemPreview() {
-    ConferenceAppFeederTheme {
+    AppThemeWithBackground {
         AnswerSurveyItem(
             surveyImage = "",
             surveyMessage = "アンケートにご協力お願いします",


### PR DESCRIPTION
## Issue
- https://github.com/DroidKaigi/conference-app-2021/issues/289

## Overview (Required)
- Show background for AnswerSurveyItem Preview

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img width="300" alt="Screen Shot 2021-03-07 at 10 52 03" src="https://user-images.githubusercontent.com/744059/110226786-44407000-7f35-11eb-9135-f6c5a58b43fe.png"> | <img width="300" alt="Screen Shot 2021-03-07 at 11 08 14" src="https://user-images.githubusercontent.com/744059/110226809-75b93b80-7f35-11eb-823a-d5b76d9572c4.png">





