### PR TITLE
Rename onSelectTab to onSelectFeedTab

### DIFF
--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -83,7 +83,7 @@ fun AppContent(
                 FeedScreen(
                     onNavigationIconClick = onNavigationIconClick,
                     selectedTab = FeedTabs.ofRoutePath(feedType),
-                    onSelectedTab = { feedTabs -> actions.onSelectTab(feedTabs) },
+                    onSelectedTab = { feedTabs -> actions.onSelectFeedTab(feedTabs) },
                     onDetailClick = { feedItem: FeedItem ->
                         actions.onSelectFeed(context, feedItem)
                     }
@@ -124,7 +124,7 @@ private class AppActions(navController: NavHostController) {
         intent.launchUrl(context, Uri.parse(feedItem.link))
     }
 
-    val onSelectTab: (feedTab: FeedTabs) -> Unit = { tab ->
+    val onSelectFeedTab: (feedTab: FeedTabs) -> Unit = { tab ->
         navController.navigate("feed/${tab.routePath}")
     }
 


### PR DESCRIPTION
## Issue
- close #233 

## Overview (Required)
- Renamed name of method  `onSelectTab ` to `onSelectFeedTab`

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
