### PR TITLE
Refresh feeds on clicked Snackbar reload button

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -97,9 +97,6 @@ fun FeedScreen(
                     )
                 ) {
                     SnackbarResult.ActionPerformed -> {
-                        scaffoldState.snackbarHostState.showSnackbar(
-                            "Sorry, Currently not implemented."
-                        )
                         dispatch(FeedViewModel.Event.ReloadContent)
                     }
                     SnackbarResult.Dismissed -> {

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealFeedViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealFeedViewModel.kt
@@ -91,7 +91,7 @@ class RealFeedViewModel @Inject constructor(
                     }
                 }
                 is FeedViewModel.Event.ReloadContent -> {
-                    // Sorry, Currently not implemented
+                    repository.refresh()
                 }
             }
         }


### PR DESCRIPTION
## Issue
- close #290

## Overview (Required)
- Call FeedRepository#refresh when click reload button of SnackBar

## Links
none

## Screenshot
none