### PR TITLE
Separate Ktor settings from platform-specific and common

### DIFF
--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -71,6 +71,7 @@ object Dep {
         const val json = "io.ktor:ktor-client-json"
         const val logging = "io.ktor:ktor-client-logging"
         const val okHttp = "io.ktor:ktor-client-okhttp"
+        const val ios = "io.ktor:ktor-client-ios"
         const val serialization = "io.ktor:ktor-client-serialization"
         const val mock = "io.ktor:ktor-client-mock"
     }

--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -19,20 +19,8 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).all {
 
 kotlin {
     android()
-//    jvm()
-    // currently firebase-auth not supported iOS
-    // https://github.com/GitLiveApp/firebase-kotlin-sdk/issues/133
-//    if (System.getProperty("idea.active") == "true") {
-//        // Fix IntelliJ Unresolved reference
-//        def onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos") ?: false
-//        if (onPhone) {
-//            iosArm64("ios")
-//        } else {
-//            iosX64("ios")
-//        }
-//    } else {
-//        ios()
-//    }
+    ios()
+
     sourceSets {
         commonMain.dependencies {
             api project(":model")
@@ -87,6 +75,9 @@ kotlin {
             kotlin {
                 srcDir 'src/androidTest'
             }
+        }
+        iosMain.dependencies {
+            implementation Dep.Ktor.ios
         }
 //            // For instrumentation tests
 //            androidTestImplementation  "com.google.dagger:hilt-android-testing:2.31.2-alpha"

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/AuthApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/AuthApi.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.feeder.data
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.auth
 import io.github.droidkaigi.feeder.Logger
-import io.ktor.client.HttpClient
 import io.ktor.client.features.ResponseException
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -14,7 +13,7 @@ import io.ktor.http.contentType
 import kotlinx.coroutines.flow.first
 
 class AuthApi(
-    private val httpClient: HttpClient,
+    private val networkService: NetworkService,
     private val userDataStore: UserDataStore,
 ) {
     suspend fun <T> authenticated(block: suspend () -> T): T {
@@ -45,7 +44,7 @@ class AuthApi(
 
     private suspend fun registerToServer(createdIdToken: String) {
         runCatching {
-            httpClient.post<String>("https://ssot-api-staging.an.r.appspot.com/accounts") {
+            networkService.httpClient.post<String>("https://ssot-api-staging.an.r.appspot.com/accounts") {
                 header(HttpHeaders.Authorization, "Bearer $createdIdToken")
                 contentType(ContentType.Application.Json)
                 body = "{}"

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/AuthApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/AuthApi.kt
@@ -44,11 +44,12 @@ class AuthApi(
 
     private suspend fun registerToServer(createdIdToken: String) {
         runCatching {
-            networkService.httpClient.post<String>("https://ssot-api-staging.an.r.appspot.com/accounts") {
-                header(HttpHeaders.Authorization, "Bearer $createdIdToken")
-                contentType(ContentType.Application.Json)
-                body = "{}"
-            }
+            networkService.httpClient
+                .post<String>("https://ssot-api-staging.an.r.appspot.com/accounts") {
+                    header(HttpHeaders.Authorization, "Bearer $createdIdToken")
+                    contentType(ContentType.Application.Json)
+                    body = "{}"
+                }
         }.getOrElse {
             if (it !is ResponseException || it.response.status != HttpStatusCode.Conflict) {
                 throw it

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorContributorApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorContributorApi.kt
@@ -2,7 +2,6 @@ package io.github.droidkaigi.feeder.data
 
 import io.github.droidkaigi.feeder.Contributor
 import io.github.droidkaigi.feeder.data.response.ContributorsResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 
 open class KtorContributorApi(

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorContributorApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorContributorApi.kt
@@ -7,10 +7,10 @@ import io.ktor.client.request.get
 
 open class KtorContributorApi(
     private val authApi: AuthApi,
-    private val httpClient: HttpClient,
+    private val networkService: NetworkService,
 ) : ContributorApi {
     override suspend fun fetch(): List<Contributor> = authApi.authenticated {
-        httpClient.get<ContributorsResponse>(
+        networkService.httpClient.get<ContributorsResponse>(
             "https://ssot-api-staging.an.r.appspot.com/contributors"
         ).toContributorList()
     }

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorDeviceApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorDeviceApi.kt
@@ -13,12 +13,13 @@ import io.ktor.http.contentType
 
 open class KtorDeviceApi(
     private val authApi: AuthApi,
-    private val httpClient: HttpClient,
+    private val networkService: NetworkService,
 ) : DeviceApi {
 
     override suspend fun create(): DeviceInfo =
         authApi.authenticated {
-            httpClient.post<DeviceResponse>("https://ssot-api-staging.an.r.appspot.com/devices") {
+            networkService.httpClient.post<DeviceResponse>("https://ssot-api-staging.an.r.appspot" +
+                ".com/devices") {
                 contentType(ContentType.Application.Json)
                 body = DevicePostRequest(platform())
             }.toDeviceInfo()
@@ -26,7 +27,7 @@ open class KtorDeviceApi(
 
     override suspend fun update(deviceId: String, deviceToken: String?): DeviceInfo =
         authApi.authenticated {
-            httpClient.put<DeviceResponse>(
+            networkService.httpClient.put<DeviceResponse>(
                 "https://ssot-api-staging.an.r.appspot.com/devices/$deviceId"
             ) {
                 contentType(ContentType.Application.Json)

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorDeviceApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorDeviceApi.kt
@@ -5,7 +5,6 @@ import io.github.droidkaigi.feeder.data.request.DevicePostRequest
 import io.github.droidkaigi.feeder.data.request.DevicePutRequest
 import io.github.droidkaigi.feeder.data.request.platform
 import io.github.droidkaigi.feeder.data.response.DeviceResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.http.ContentType
@@ -18,8 +17,10 @@ open class KtorDeviceApi(
 
     override suspend fun create(): DeviceInfo =
         authApi.authenticated {
-            networkService.httpClient.post<DeviceResponse>("https://ssot-api-staging.an.r.appspot" +
-                ".com/devices") {
+            networkService.httpClient.post<DeviceResponse>(
+                "https://ssot-api-staging.an.r.appspot" +
+                    ".com/devices"
+            ) {
                 contentType(ContentType.Application.Json)
                 body = DevicePostRequest(platform())
             }.toDeviceInfo()

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorFeedApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorFeedApi.kt
@@ -8,7 +8,6 @@ import io.github.droidkaigi.feeder.MultiLangText
 import io.github.droidkaigi.feeder.data.response.FeedsResponse
 import io.github.droidkaigi.feeder.data.response.Speaker
 import io.github.droidkaigi.feeder.data.response.Thumbnail
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 
 open class KtorFeedApi(

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorFeedApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorFeedApi.kt
@@ -13,11 +13,11 @@ import io.ktor.client.request.get
 
 open class KtorFeedApi(
     private val authApi: AuthApi,
-    private val httpClient: HttpClient,
+    private val networkService: NetworkService,
 ) : FeedApi {
 
     override suspend fun fetch(): List<FeedItem> = authApi.authenticated {
-        val feedsResponse = httpClient.get<FeedsResponse>(
+        val feedsResponse = networkService.httpClient.get<FeedsResponse>(
             "https://ssot-api-staging.an.r.appspot.com/feeds/recent",
         )
         feedsResponse.toFeedList()

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorStaffApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorStaffApi.kt
@@ -2,7 +2,6 @@ package io.github.droidkaigi.feeder.data
 
 import io.github.droidkaigi.feeder.Staff
 import io.github.droidkaigi.feeder.data.response.StaffResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 
 open class KtorStaffApi(

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorStaffApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorStaffApi.kt
@@ -7,11 +7,11 @@ import io.ktor.client.request.get
 
 open class KtorStaffApi(
     private val authApi: AuthApi,
-    private val httpClient: HttpClient,
+    private val networkService: NetworkService,
 ) : StaffApi {
 
     override suspend fun fetch(): List<Staff> = authApi.authenticated {
-        val staffResponse = httpClient.get<StaffResponse>(
+        val staffResponse = networkService.httpClient.get<StaffResponse>(
             "https://ssot-api-staging.an.r.appspot.com/staff",
         )
         staffResponse.toStaffList()

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/NetworkService.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/NetworkService.kt
@@ -18,9 +18,11 @@ import kotlinx.serialization.modules.contextual
 class NetworkService private constructor(val httpClient: HttpClient) {
 
     companion object {
-        fun <T> create(engineFactory: HttpClientEngineFactory<T>,
-                       userDataStore: UserDataStore,
-                       block: T.() -> Unit = {}) : NetworkService where T: HttpClientEngineConfig {
+        fun <T> create(
+            engineFactory: HttpClientEngineFactory<T>,
+            userDataStore: UserDataStore,
+            block: T.() -> Unit = {}
+        ): NetworkService where T : HttpClientEngineConfig {
             val httpClient = HttpClient(engineFactory) {
                 engine(block)
                 install(JsonFeature) {
@@ -52,5 +54,4 @@ class NetworkService private constructor(val httpClient: HttpClient) {
             return NetworkService(httpClient)
         }
     }
-
 }

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/NetworkService.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/NetworkService.kt
@@ -1,0 +1,56 @@
+package io.github.droidkaigi.feeder.data
+
+import io.github.droidkaigi.feeder.data.response.InstantSerializer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.features.defaultRequest
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.features.logging.Logger
+import io.ktor.client.features.logging.Logging
+import io.ktor.client.request.headers
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+
+class NetworkService private constructor(val httpClient: HttpClient) {
+
+    companion object {
+        fun <T> create(engineFactory: HttpClientEngineFactory<T>,
+                       userDataStore: UserDataStore,
+                       block: T.() -> Unit = {}) : NetworkService where T: HttpClientEngineConfig {
+            val httpClient = HttpClient(engineFactory) {
+                engine(block)
+                install(JsonFeature) {
+                    serializer = KotlinxSerializer(
+                        Json {
+                            serializersModule = SerializersModule {
+                                contextual(InstantSerializer)
+                            }
+                            ignoreUnknownKeys = true
+                        }
+                    )
+                }
+                install(Logging) {
+                    logger = object : Logger {
+                        override fun log(message: String) {
+                            io.github.droidkaigi.feeder.Logger.d(message)
+                        }
+                    }
+                    level = LogLevel.ALL
+                }
+                defaultRequest {
+                    headers {
+                        userDataStore.idToken.value?.let {
+                            set("Authorization", "Bearer $it")
+                        }
+                    }
+                }
+            }
+            return NetworkService(httpClient)
+        }
+    }
+
+}

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/ApiModule.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/ApiModule.kt
@@ -5,8 +5,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.ktor.client.engine.okhttp.OkHttp
-import okhttp3.Interceptor
 import javax.inject.Singleton
+import okhttp3.Interceptor
 
 @InstallIn(SingletonComponent::class)
 @Module
@@ -16,10 +16,12 @@ class ApiModule {
     @Provides
     internal fun provideNetworkService(
         userDataStore: UserDataStore,
-        networkInterceptors: List<@JvmSuppressWildcards Interceptor>) : NetworkService {
+        networkInterceptors: List<@JvmSuppressWildcards Interceptor>
+    ): NetworkService {
         return NetworkService.create(
             engineFactory = OkHttp,
-            userDataStore = userDataStore) {
+            userDataStore = userDataStore
+        ) {
             networkInterceptors.forEach { addNetworkInterceptor(it) }
         }
     }

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/ApiModule.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/ApiModule.kt
@@ -4,70 +4,32 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import io.github.droidkaigi.feeder.Logger as DroidKaigiLogger
-import io.github.droidkaigi.feeder.data.response.InstantSerializer
-import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.features.defaultRequest
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.features.logging.LogLevel
-import io.ktor.client.features.logging.Logger
-import io.ktor.client.features.logging.Logging
-import io.ktor.client.request.headers
-import javax.inject.Singleton
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.contextual
 import okhttp3.Interceptor
+import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module
 class ApiModule {
+
     @Singleton
     @Provides
-    internal fun provideHttpClient(
+    internal fun provideNetworkService(
         userDataStore: UserDataStore,
-        networkInterceptors: List<@JvmSuppressWildcards Interceptor>,
-    ): HttpClient {
-        return HttpClient(OkHttp) {
-            engine {
-                networkInterceptors.forEach { addNetworkInterceptor(it) }
-            }
-            install(JsonFeature) {
-                serializer = KotlinxSerializer(
-                    json = Json {
-                        serializersModule = SerializersModule {
-                            contextual(InstantSerializer)
-                        }
-                        ignoreUnknownKeys = true
-                    }
-                )
-            }
-            install(Logging) {
-                logger = object : Logger {
-                    override fun log(message: String) {
-                        DroidKaigiLogger.d(message)
-                    }
-                }
-                level = LogLevel.ALL
-            }
-            defaultRequest {
-                headers {
-                    userDataStore.idToken.value?.let {
-                        set("Authorization", "Bearer $it")
-                    }
-                }
-            }
+        networkInterceptors: List<@JvmSuppressWildcards Interceptor>) : NetworkService {
+        return NetworkService.create(
+            engineFactory = OkHttp,
+            userDataStore = userDataStore) {
+            networkInterceptors.forEach { addNetworkInterceptor(it) }
         }
     }
 
     @Singleton
     @Provides
     internal fun provideFirebaseAuthApi(
-        httpClient: HttpClient,
+        networkService: NetworkService,
         userDataStore: UserDataStore,
     ): AuthApi {
-        return AuthApi(httpClient, userDataStore)
+        return AuthApi(networkService, userDataStore)
     }
 }

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorContributorApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorContributorApi.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.feeder.data
 
-import io.ktor.client.HttpClient
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorContributorApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorContributorApi.kt
@@ -7,5 +7,5 @@ import javax.inject.Singleton
 @Singleton
 class DaggerKtorContributorApi @Inject constructor(
     authApi: AuthApi,
-    httpClient: HttpClient,
-) : KtorContributorApi(authApi, httpClient)
+    networkService: NetworkService,
+) : KtorContributorApi(authApi, networkService)

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorDeviceApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorDeviceApi.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.feeder.data
 
-import io.ktor.client.HttpClient
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorDeviceApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorDeviceApi.kt
@@ -7,5 +7,5 @@ import javax.inject.Singleton
 @Singleton
 class DaggerKtorDeviceApi @Inject constructor(
     authApi: AuthApi,
-    httpClient: HttpClient,
-) : KtorDeviceApi(authApi, httpClient)
+    networkService: NetworkService,
+) : KtorDeviceApi(authApi, networkService)

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorFeedApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorFeedApi.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.feeder.data
 
-import io.ktor.client.HttpClient
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorFeedApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorFeedApi.kt
@@ -7,5 +7,5 @@ import javax.inject.Singleton
 @Singleton
 class DaggerKtorFeedApi @Inject constructor(
     authApi: AuthApi,
-    httpClient: HttpClient,
-) : KtorFeedApi(authApi, httpClient)
+    networkService: NetworkService,
+) : KtorFeedApi(authApi, networkService)

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorStaffApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorStaffApi.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.feeder.data
 
-import io.ktor.client.HttpClient
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorStaffApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorStaffApi.kt
@@ -7,5 +7,5 @@ import javax.inject.Singleton
 @Singleton
 class DaggerKtorStaffApi @Inject constructor(
     authApi: AuthApi,
-    httpClient: HttpClient,
-) : KtorStaffApi(authApi, httpClient)
+    networkService: NetworkService,
+) : KtorStaffApi(authApi, networkService)


### PR DESCRIPTION
## Issue
- close #94

## Overview (Required)
- Add ktors `HttpClient` wrapper
- Perform common configuration via this wrapper

... and Add iOS target and dependencies

## Links
-

## Screenshot
🙅‍♂️