### PR TITLE
Rename "Tabs" to "Tab" of screens

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -59,14 +59,14 @@ import kotlin.math.abs
 import kotlin.reflect.KClass
 import kotlinx.coroutines.launch
 
-sealed class FeedTabs(val name: String, val routePath: String) {
-    object Home : FeedTabs("Home", "home")
+sealed class FeedTab(val name: String, val routePath: String) {
+    object Home : FeedTab("Home", "home")
     sealed class FilteredFeed(
         val feedItemClass: KClass<out FeedItem>,
         name: String,
         routePath: String,
     ) :
-        FeedTabs(name, routePath) {
+        FeedTab(name, routePath) {
         object Blog : FilteredFeed(FeedItem.Blog::class, "Blog", "blog")
         object Video : FilteredFeed(FeedItem.Video::class, "Video", "video")
         object Podcast : FilteredFeed(FeedItem.Podcast::class, "Podcast", "podcast")
@@ -83,8 +83,8 @@ sealed class FeedTabs(val name: String, val routePath: String) {
  */
 @Composable
 fun FeedScreen(
-    selectedTab: FeedTabs,
-    onSelectedTab: (FeedTabs) -> Unit,
+    selectedTab: FeedTab,
+    onSelectedTab: (FeedTab) -> Unit,
     onNavigationIconClick: () -> Unit,
     onDetailClick: (FeedItem) -> Unit,
 ) {
@@ -155,7 +155,7 @@ fun FeedScreen(
                 if (0 > velocity) {
                     selectedTab.rightTab
                 } else {
-                    selectedTab.leftTabs
+                    selectedTab.leftTab
                 }
             )
         },
@@ -168,12 +168,12 @@ fun FeedScreen(
  */
 @Composable
 private fun FeedScreen(
-    selectedTab: FeedTabs,
+    selectedTab: FeedTab,
     scaffoldState: BackdropScaffoldState,
     feedContents: FeedContents,
     playingPodcastState: PlayingPodcastState?,
     filters: Filters,
-    onSelectTab: (FeedTabs) -> Unit,
+    onSelectTab: (FeedTab) -> Unit,
     onNavigationIconClick: () -> Unit,
     onFavoriteChange: (FeedItem) -> Unit,
     onFavoriteFilterChanged: (filtered: Boolean) -> Unit,
@@ -198,9 +198,9 @@ private fun FeedScreen(
             },
             frontLayerContent = {
                 FadeThrough(targetState = selectedTab) { selectedTab ->
-                    val isHome = selectedTab is FeedTabs.Home
+                    val isHome = selectedTab is FeedTab.Home
                     FeedList(
-                        feedContents = if (selectedTab is FeedTabs.FilteredFeed) {
+                        feedContents = if (selectedTab is FeedTab.FilteredFeed) {
                             feedContents.filterFeedType(selectedTab.feedItemClass)
                         } else {
                             feedContents
@@ -220,23 +220,23 @@ private fun FeedScreen(
     }
 }
 
-private val FeedTabs.rightTab: FeedTabs
+private val FeedTab.rightTab: FeedTab
     get() {
-        val currentPosition = FeedTabs.values().indexOf(this)
-        return FeedTabs.values().getOrElse(currentPosition + 1) { this }
+        val currentPosition = FeedTab.values().indexOf(this)
+        return FeedTab.values().getOrElse(currentPosition + 1) { this }
     }
 
-private val FeedTabs.leftTabs: FeedTabs
+private val FeedTab.leftTab: FeedTab
     get() {
-        val currentPosition = FeedTabs.values().indexOf(this)
-        return FeedTabs.values().getOrElse(currentPosition - 1) { this }
+        val currentPosition = FeedTab.values().indexOf(this)
+        return FeedTab.values().getOrElse(currentPosition - 1) { this }
     }
 
 @Composable
 private fun AppBar(
     onNavigationIconClick: () -> Unit,
-    selectedTab: FeedTabs,
-    onSelectTab: (FeedTabs) -> Unit,
+    selectedTab: FeedTab,
+    onSelectTab: (FeedTab) -> Unit,
 ) {
     TopAppBar(
         modifier = Modifier.statusBarsPadding(),
@@ -248,7 +248,7 @@ private fun AppBar(
             }
         }
     )
-    val selectedTabIndex = FeedTabs.values().indexOf(selectedTab)
+    val selectedTabIndex = FeedTab.values().indexOf(selectedTab)
     ScrollableTabRow(
         selectedTabIndex = 0,
         edgePadding = 0.dp,
@@ -260,7 +260,7 @@ private fun AppBar(
         },
         divider = {}
     ) {
-        FeedTabs.values().forEach { tab ->
+        FeedTab.values().forEach { tab ->
             Tab(
                 selected = tab == selectedTab,
                 text = {
@@ -407,7 +407,7 @@ fun PreviewFeedScreen() {
     AppThemeWithBackground {
         ProvideFeedViewModel(viewModel = fakeFeedViewModel()) {
             FeedScreen(
-                selectedTab = FeedTabs.Home,
+                selectedTab = FeedTab.Home,
                 onSelectedTab = {},
                 onNavigationIconClick = {
                 }
@@ -423,7 +423,7 @@ fun PreviewFeedScreenWithStartBlog() {
     AppThemeWithBackground {
         ProvideFeedViewModel(viewModel = fakeFeedViewModel()) {
             FeedScreen(
-                selectedTab = FeedTabs.FilteredFeed.Blog,
+                selectedTab = FeedTab.FilteredFeed.Blog,
                 onSelectedTab = {},
                 onNavigationIconClick = {
                 }

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -26,10 +26,10 @@ import io.github.droidkaigi.feeder.core.navigation.chromeCustomTabs
 import io.github.droidkaigi.feeder.core.navigation.navigateChromeCustomTabs
 import io.github.droidkaigi.feeder.core.navigation.rememberCustomNavController
 import io.github.droidkaigi.feeder.feed.FeedScreen
-import io.github.droidkaigi.feeder.feed.FeedTabs
+import io.github.droidkaigi.feeder.feed.FeedTab
 import io.github.droidkaigi.feeder.main.R
 import io.github.droidkaigi.feeder.other.OtherScreen
-import io.github.droidkaigi.feeder.other.OtherTabs
+import io.github.droidkaigi.feeder.other.OtherTab
 import kotlinx.coroutines.launch
 
 private const val FEED_PATH = "feed/"
@@ -83,17 +83,17 @@ fun AppContent(
             ) { backStackEntry ->
                 val routePath = rememberRoutePath(
                     backStackEntry.arguments?.getString("feedTab")
-                        ?: FeedTabs.Home.routePath
+                        ?: FeedTab.Home.routePath
                 )
-                val selectedTab = FeedTabs.ofRoutePath(routePath.value)
+                val selectedTab = FeedTab.ofRoutePath(routePath.value)
                 drawerContentState.onSelectDrawerContent(selectedTab)
                 FeedScreen(
                     onNavigationIconClick = onNavigationIconClick,
                     selectedTab = selectedTab,
-                    onSelectedTab = { feedTabs ->
+                    onSelectedTab = { feedTab ->
                         // We don't use navigation component transitions here for animation.
-                        routePath.value = feedTabs.routePath
-                        drawerContentState.onSelectDrawerContent(feedTabs)
+                        routePath.value = feedTab.routePath
+                        drawerContentState.onSelectDrawerContent(feedTab)
                     },
                     onDetailClick = { feedItem: FeedItem ->
                         actions.showChromeCustomTabs(feedItem.link)
@@ -115,16 +115,16 @@ fun AppContent(
             ) { backStackEntry ->
                 val routePath = rememberRoutePath(
                     backStackEntry.arguments?.getString("otherTab")
-                        ?: OtherTabs.AboutThisApp.routePath
+                        ?: OtherTab.AboutThisApp.routePath
                 )
-                val selectedTab = OtherTabs.ofRoutePath(routePath.value)
+                val selectedTab = OtherTab.ofRoutePath(routePath.value)
                 drawerContentState.onSelectDrawerContent(selectedTab)
                 OtherScreen(
                     selectedTab = selectedTab,
-                    onSelectTab = { otherTabs ->
+                    onSelectTab = { otherTab ->
                         // We don't use navigation component transitions here for animation.
-                        routePath.value = otherTabs.routePath
-                        drawerContentState.onSelectDrawerContent(otherTabs)
+                        routePath.value = otherTab.routePath
+                        drawerContentState.onSelectDrawerContent(otherTab)
                     },
                     onNavigationIconClick = onNavigationIconClick,
                     onContributorClick = { contributor ->

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
@@ -28,9 +28,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.droidkaigi.feeder.core.theme.AppThemeWithBackground
-import io.github.droidkaigi.feeder.feed.FeedTabs
+import io.github.droidkaigi.feeder.feed.FeedTab
 import io.github.droidkaigi.feeder.main.R
-import io.github.droidkaigi.feeder.other.OtherTabs
+import io.github.droidkaigi.feeder.other.OtherTab
 
 enum class DrawerContents(
     val group: Group,
@@ -43,49 +43,49 @@ enum class DrawerContents(
         group = Group.NEWS,
         imageResId = R.drawable.ic_baseline_home_24,
         label = "HOME",
-        route = "feed/${FeedTabs.Home.routePath}"
+        route = "feed/${FeedTab.Home.routePath}"
     ),
     BLOG(
         group = Group.NEWS,
         imageResId = R.drawable.ic_baseline_text_snippet_24,
         label = "BLOG",
-        route = "feed/${FeedTabs.FilteredFeed.Blog.routePath}"
+        route = "feed/${FeedTab.FilteredFeed.Blog.routePath}"
     ),
     VIDEO(
         group = Group.NEWS,
         imageResId = R.drawable.ic_baseline_videocam_24,
         label = "VIDEO",
-        route = "feed/${FeedTabs.FilteredFeed.Video.routePath}"
+        route = "feed/${FeedTab.FilteredFeed.Video.routePath}"
     ),
     PODCAST(
         group = Group.NEWS,
         imageResId = R.drawable.ic_baseline_mic_none_24,
         label = "PODCAST",
-        route = "feed/${FeedTabs.FilteredFeed.Podcast.routePath}"
+        route = "feed/${FeedTab.FilteredFeed.Podcast.routePath}"
     ),
     ABOUT_DROIDKAIGI(
         group = Group.OTHER,
         imageResId = R.drawable.ic_baseline_android_24,
         label = "ABOUT",
-        route = "other/${OtherTabs.AboutThisApp.routePath}"
+        route = "other/${OtherTab.AboutThisApp.routePath}"
     ),
     CONTRIBUTOR(
         group = Group.OTHER,
         imageResId = R.drawable.ic_outline_people_24,
         label = "CONTRIBUTOR",
-        route = "other/${OtherTabs.Contributor.routePath}"
+        route = "other/${OtherTab.Contributor.routePath}"
     ),
     STAFF(
         group = Group.OTHER,
         imageResId = R.drawable.ic_baseline_face_24,
         label = "STAFF",
-        route = "other/${OtherTabs.Staff.routePath}"
+        route = "other/${OtherTab.Staff.routePath}"
     ),
     SETTING(
         group = Group.OTHER,
         imageResId = R.drawable.ic_baseline_settings_24,
         label = "SETTING",
-        route = "other/${OtherTabs.Settings.routePath}",
+        route = "other/${OtherTab.Settings.routePath}",
     ),
     ;
 
@@ -109,12 +109,12 @@ class DrawerContentState(
         }
     }
 
-    fun onSelectDrawerContent(feedTabs: FeedTabs) {
-        selectDrawerContent("feed/${feedTabs.routePath}")
+    fun onSelectDrawerContent(feedTab: FeedTab) {
+        selectDrawerContent("feed/${feedTab.routePath}")
     }
 
-    fun onSelectDrawerContent(otherTabs: OtherTabs) {
-        selectDrawerContent("other/${otherTabs.routePath}")
+    fun onSelectDrawerContent(otherTab: OtherTab) {
+        selectDrawerContent("other/${otherTab.routePath}")
     }
 
     companion object {

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
@@ -38,11 +38,11 @@ import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 import io.github.droidkaigi.feeder.setting.Settings
 import io.github.droidkaigi.feeder.staff.StaffList
 
-sealed class OtherTabs(val name: String, val routePath: String) {
-    object AboutThisApp : OtherTabs("About", "about")
-    object Contributor : OtherTabs("Contributor", "contributor")
-    object Staff : OtherTabs("Staff", "about_this_app")
-    object Settings : OtherTabs("Setting", "setting")
+sealed class OtherTab(val name: String, val routePath: String) {
+    object AboutThisApp : OtherTab("About", "about")
+    object Contributor : OtherTab("Contributor", "contributor")
+    object Staff : OtherTab("Staff", "about_this_app")
+    object Settings : OtherTab("Setting", "setting")
 
     companion object {
         fun values() = listOf(AboutThisApp, Contributor, Staff, Settings)
@@ -56,8 +56,8 @@ sealed class OtherTabs(val name: String, val routePath: String) {
  */
 @Composable
 fun OtherScreen(
-    selectedTab: OtherTabs,
-    onSelectTab: (OtherTabs) -> Unit,
+    selectedTab: OtherTab,
+    onSelectTab: (OtherTab) -> Unit,
     onNavigationIconClick: () -> Unit,
     onContributorClick: (Contributor) -> Unit,
     onStaffClick: (Staff) -> Unit,
@@ -80,8 +80,8 @@ fun OtherScreen(
 @Composable
 fun OtherScreen(
     scaffoldState: BackdropScaffoldState,
-    selectedTab: OtherTabs,
-    onSelectTab: (OtherTabs) -> Unit,
+    selectedTab: OtherTab,
+    onSelectTab: (OtherTab) -> Unit,
     onNavigationIconClick: () -> Unit,
     onContributorClick: (Contributor) -> Unit,
     onStaffClick: (Staff) -> Unit,
@@ -117,8 +117,8 @@ fun OtherScreen(
 @Composable
 private fun AppBar(
     onNavigationIconClick: () -> Unit,
-    selectedTab: OtherTabs,
-    onSelectTab: (OtherTabs) -> Unit,
+    selectedTab: OtherTab,
+    onSelectTab: (OtherTab) -> Unit,
 ) {
     TopAppBar(
         modifier = Modifier.statusBarsPadding(),
@@ -130,7 +130,7 @@ private fun AppBar(
             }
         }
     )
-    val selectedTabIndex = OtherTabs.values().indexOf(selectedTab)
+    val selectedTabIndex = OtherTab.values().indexOf(selectedTab)
     ScrollableTabRow(
         selectedTabIndex = 0,
         edgePadding = 0.dp,
@@ -142,7 +142,7 @@ private fun AppBar(
         },
         divider = {}
     ) {
-        OtherTabs.values().forEach { tab ->
+        OtherTab.values().forEach { tab ->
             Tab(
                 selected = tab == selectedTab,
                 text = {
@@ -159,15 +159,15 @@ private fun AppBar(
 
 @Composable
 private fun BackdropFrontLayerContent(
-    selectedTab: OtherTabs,
+    selectedTab: OtherTab,
     onContributorClick: (Contributor) -> Unit,
     onStaffClick: (Staff) -> Unit,
 ) {
     when (selectedTab) {
-        OtherTabs.AboutThisApp -> AboutThisApp()
-        OtherTabs.Contributor -> ContributorList(onContributorClick)
-        OtherTabs.Settings -> Settings()
-        OtherTabs.Staff -> StaffList(onStaffClick)
+        OtherTab.AboutThisApp -> AboutThisApp()
+        OtherTab.Contributor -> ContributorList(onContributorClick)
+        OtherTab.Settings -> Settings()
+        OtherTab.Staff -> StaffList(onStaffClick)
     }
 }
 
@@ -176,7 +176,7 @@ private fun BackdropFrontLayerContent(
 fun PreviewOtherScreen() {
     ConferenceAppFeederTheme {
         OtherScreen(
-            selectedTab = OtherTabs.AboutThisApp,
+            selectedTab = OtherTab.AboutThisApp,
             onSelectTab = {
             },
             onNavigationIconClick = {


### PR DESCRIPTION
## Issue
- close #360 

## Overview (Required)
- renamed FeedTabs to FeedTab (requirement of this issue)
- same reason of issue, renamed OtherTabs to OtherTab
  - if no need to rename about OtherTabs, I will rollback this.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
