### PR TITLE
bring authApi into NetworkService

### DIFF
--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/ApiHttpClient.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/ApiHttpClient.kt
@@ -1,0 +1,53 @@
+package io.github.droidkaigi.feeder.data
+
+import io.github.droidkaigi.feeder.data.response.InstantSerializer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.features.defaultRequest
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.features.logging.Logger
+import io.ktor.client.features.logging.Logging
+import io.ktor.client.request.headers
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+
+object ApiHttpClient {
+    internal fun <T> create(
+        engineFactory: HttpClientEngineFactory<T>,
+        userDataStore: UserDataStore,
+        block: T.() -> Unit = {},
+    ): HttpClient where T : HttpClientEngineConfig {
+        return HttpClient(engineFactory) {
+            engine(block)
+            install(JsonFeature) {
+                serializer = KotlinxSerializer(
+                    Json {
+                        serializersModule = SerializersModule {
+                            contextual(InstantSerializer)
+                        }
+                        ignoreUnknownKeys = true
+                    }
+                )
+            }
+            install(Logging) {
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        io.github.droidkaigi.feeder.Logger.d(message)
+                    }
+                }
+                level = LogLevel.ALL
+            }
+            defaultRequest {
+                headers {
+                    userDataStore.idToken.value?.let {
+                        set("Authorization", "Bearer $it")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorContributorApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorContributorApi.kt
@@ -2,17 +2,14 @@ package io.github.droidkaigi.feeder.data
 
 import io.github.droidkaigi.feeder.Contributor
 import io.github.droidkaigi.feeder.data.response.ContributorsResponse
-import io.ktor.client.request.get
 
 open class KtorContributorApi(
-    private val authApi: AuthApi,
     private val networkService: NetworkService,
 ) : ContributorApi {
-    override suspend fun fetch(): List<Contributor> = authApi.authenticated {
-        networkService.get<ContributorsResponse>(
-            "https://ssot-api-staging.an.r.appspot.com/contributors"
-        ).toContributorList()
-    }
+    override suspend fun fetch(): List<Contributor> = networkService.get<ContributorsResponse>(
+        "https://ssot-api-staging.an.r.appspot.com/contributors",
+        needAuth = true
+    ).toContributorList()
 }
 
 fun ContributorsResponse.toContributorList(): List<Contributor> {

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorDeviceApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorDeviceApi.kt
@@ -9,30 +9,26 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 
 open class KtorDeviceApi(
-    private val authApi: AuthApi,
     private val networkService: NetworkService,
 ) : DeviceApi {
 
-    override suspend fun create(): DeviceInfo =
-        authApi.authenticated {
-            networkService.post<DeviceResponse>(
-                "https://ssot-api-staging.an.r.appspot" +
-                    ".com/devices"
-            ) {
-                contentType(ContentType.Application.Json)
-                body = DevicePostRequest(platform())
-            }.toDeviceInfo()
-        }
+    override suspend fun create(): DeviceInfo = networkService.post<DeviceResponse>(
+        "https://ssot-api-staging.an.r.appspot" +
+            ".com/devices",
+        needAuth = true
+    ) {
+        contentType(ContentType.Application.Json)
+        body = DevicePostRequest(platform())
+    }.toDeviceInfo()
 
     override suspend fun update(deviceId: String, deviceToken: String?): DeviceInfo =
-        authApi.authenticated {
-            networkService.put<DeviceResponse>(
-                "https://ssot-api-staging.an.r.appspot.com/devices/$deviceId"
-            ) {
-                contentType(ContentType.Application.Json)
-                body = DevicePutRequest(deviceToken)
-            }.toDeviceInfo()
-        }
+        networkService.put<DeviceResponse>(
+            "https://ssot-api-staging.an.r.appspot.com/devices/$deviceId",
+            needAuth = true
+        ) {
+            contentType(ContentType.Application.Json)
+            body = DevicePutRequest(deviceToken)
+        }.toDeviceInfo()
 }
 
 private fun DeviceResponse.toDeviceInfo(): DeviceInfo {

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorFeedApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorFeedApi.kt
@@ -8,20 +8,17 @@ import io.github.droidkaigi.feeder.MultiLangText
 import io.github.droidkaigi.feeder.data.response.FeedsResponse
 import io.github.droidkaigi.feeder.data.response.Speaker
 import io.github.droidkaigi.feeder.data.response.Thumbnail
-import io.ktor.client.request.get
 
 open class KtorFeedApi(
-    private val authApi: AuthApi,
     private val networkService: NetworkService,
 ) : FeedApi {
 
     override suspend fun fetch(): List<FeedItem> = try {
-        authApi.authenticated {
-            val feedsResponse = networkService.httpClient.get<FeedsResponse>(
-                "https://ssot-api-staging.an.r.appspot.com/feeds/recent",
-            )
-            feedsResponse.toFeedList()
-        }
+        val feedsResponse = networkService.get<FeedsResponse>(
+            "https://ssot-api-staging.an.r.appspot.com/feeds/recent",
+            needAuth = true
+        )
+        feedsResponse.toFeedList()
     } catch (e: Throwable) {
         // null value is not come here
         throw e.toAppError()

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorStaffApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorStaffApi.kt
@@ -2,19 +2,15 @@ package io.github.droidkaigi.feeder.data
 
 import io.github.droidkaigi.feeder.Staff
 import io.github.droidkaigi.feeder.data.response.StaffResponse
-import io.ktor.client.request.get
 
 open class KtorStaffApi(
-    private val authApi: AuthApi,
     private val networkService: NetworkService,
 ) : StaffApi {
 
-    override suspend fun fetch(): List<Staff> = authApi.authenticated {
-        val staffResponse = networkService.get<StaffResponse>(
-            "https://ssot-api-staging.an.r.appspot.com/staff",
-        )
-        staffResponse.toStaffList()
-    }
+    override suspend fun fetch(): List<Staff> = networkService.get<StaffResponse>(
+        "https://ssot-api-staging.an.r.appspot.com/staff",
+        needAuth = true
+    ).toStaffList()
 }
 
 fun StaffResponse.toStaffList() =

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/NetworkService.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/NetworkService.kt
@@ -1,75 +1,42 @@
 package io.github.droidkaigi.feeder.data
 
-import io.github.droidkaigi.feeder.data.response.InstantSerializer
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.HttpClientEngineConfig
-import io.ktor.client.engine.HttpClientEngineFactory
-import io.ktor.client.features.defaultRequest
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.features.logging.LogLevel
-import io.ktor.client.features.logging.Logger
-import io.ktor.client.features.logging.Logging
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
-import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.put
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.contextual
 
-class NetworkService private constructor(val httpClient: HttpClient) {
+class NetworkService(val httpClient: HttpClient, val authApi: AuthApi) {
 
-    suspend inline fun <reified T : Any> get(url: String): T {
+    suspend inline fun <reified T : Any> get(
+        url: String,
+        needAuth: Boolean = false,
+    ): T {
+        if (needAuth) {
+            authApi.authIfNeeded()
+        }
         return httpClient.get(url)
     }
 
     suspend inline fun <reified T> post(
         urlString: String,
-        block: HttpRequestBuilder.() -> Unit = {}
-    ): T = httpClient.post<T>(urlString, block)
+        needAuth: Boolean = false,
+        block: HttpRequestBuilder.() -> Unit = {},
+    ): T {
+        if (needAuth) {
+            authApi.authIfNeeded()
+        }
+        return httpClient.post(urlString, block)
+    }
 
     suspend inline fun <reified T> put(
         urlString: String,
-        block: HttpRequestBuilder.() -> Unit = {}
-    ): T = httpClient.put<T>(urlString, block)
-
-    companion object {
-        fun <T> create(
-            engineFactory: HttpClientEngineFactory<T>,
-            userDataStore: UserDataStore,
-            block: T.() -> Unit = {},
-        ): NetworkService where T : HttpClientEngineConfig {
-            val httpClient = HttpClient(engineFactory) {
-                engine(block)
-                install(JsonFeature) {
-                    serializer = KotlinxSerializer(
-                        Json {
-                            serializersModule = SerializersModule {
-                                contextual(InstantSerializer)
-                            }
-                            ignoreUnknownKeys = true
-                        }
-                    )
-                }
-                install(Logging) {
-                    logger = object : Logger {
-                        override fun log(message: String) {
-                            io.github.droidkaigi.feeder.Logger.d(message)
-                        }
-                    }
-                    level = LogLevel.ALL
-                }
-                defaultRequest {
-                    headers {
-                        userDataStore.idToken.value?.let {
-                            set("Authorization", "Bearer $it")
-                        }
-                    }
-                }
-            }
-            return NetworkService(httpClient)
+        needAuth: Boolean = false,
+        block: HttpRequestBuilder.() -> Unit = {},
+    ): T {
+        if (needAuth) {
+            authApi.authIfNeeded()
         }
+        return httpClient.put(urlString, block)
     }
 }

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/ApiModule.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/ApiModule.kt
@@ -4,6 +4,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import javax.inject.Singleton
 import okhttp3.Interceptor
@@ -14,11 +15,11 @@ class ApiModule {
 
     @Singleton
     @Provides
-    internal fun provideNetworkService(
+    internal fun provideHttpClient(
         userDataStore: UserDataStore,
-        networkInterceptors: List<@JvmSuppressWildcards Interceptor>
-    ): NetworkService {
-        return NetworkService.create(
+        networkInterceptors: List<@JvmSuppressWildcards Interceptor>,
+    ): HttpClient {
+        return ApiHttpClient.create(
             engineFactory = OkHttp,
             userDataStore = userDataStore
         ) {
@@ -28,10 +29,19 @@ class ApiModule {
 
     @Singleton
     @Provides
+    internal fun provideNetworkService(
+        httpClient: HttpClient,
+        authApi: AuthApi,
+    ): NetworkService {
+        return NetworkService(httpClient, authApi)
+    }
+
+    @Singleton
+    @Provides
     internal fun provideFirebaseAuthApi(
-        networkService: NetworkService,
+        httpClient: HttpClient,
         userDataStore: UserDataStore,
     ): AuthApi {
-        return AuthApi(networkService, userDataStore)
+        return AuthApi(httpClient, userDataStore)
     }
 }

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorContributorApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorContributorApi.kt
@@ -5,6 +5,5 @@ import javax.inject.Singleton
 
 @Singleton
 class DaggerKtorContributorApi @Inject constructor(
-    authApi: AuthApi,
     networkService: NetworkService,
-) : KtorContributorApi(authApi, networkService)
+) : KtorContributorApi(networkService)

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorDeviceApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorDeviceApi.kt
@@ -5,6 +5,5 @@ import javax.inject.Singleton
 
 @Singleton
 class DaggerKtorDeviceApi @Inject constructor(
-    authApi: AuthApi,
     networkService: NetworkService,
-) : KtorDeviceApi(authApi, networkService)
+) : KtorDeviceApi(networkService)

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorFeedApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorFeedApi.kt
@@ -5,6 +5,5 @@ import javax.inject.Singleton
 
 @Singleton
 class DaggerKtorFeedApi @Inject constructor(
-    authApi: AuthApi,
     networkService: NetworkService,
-) : KtorFeedApi(authApi, networkService)
+) : KtorFeedApi(networkService)

--- a/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorStaffApi.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/feeder/data/DaggerKtorStaffApi.kt
@@ -5,6 +5,5 @@ import javax.inject.Singleton
 
 @Singleton
 class DaggerKtorStaffApi @Inject constructor(
-    authApi: AuthApi,
     networkService: NetworkService,
-) : KtorStaffApi(authApi, networkService)
+) : KtorStaffApi(networkService)


### PR DESCRIPTION
## Issue
- close #363 

## Overview (Required)
- execute to call `AuthApi` in `NetworkService`
- change to create `HttpClient` in `AppModule` and reuse it for `NetworkService` and `AuthApi`
- enable to pass `needAuth` flag to each call of `NetworkService` and if `true`, call `authIfNeeded` of `AuthApi`
- not to call `authenticated` directly from other api class.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
