### PR TITLE
map to ApiError in NetworkService

### DIFF
--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorFeedApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/KtorFeedApi.kt
@@ -13,16 +13,10 @@ open class KtorFeedApi(
     private val networkService: NetworkService,
 ) : FeedApi {
 
-    override suspend fun fetch(): List<FeedItem> = try {
-        val feedsResponse = networkService.get<FeedsResponse>(
-            "https://ssot-api-staging.an.r.appspot.com/feeds/recent",
-            needAuth = true
-        )
-        feedsResponse.toFeedList()
-    } catch (e: Throwable) {
-        // null value is not come here
-        throw e.toAppError()
-    }
+    override suspend fun fetch(): List<FeedItem> = networkService.get<FeedsResponse>(
+        "https://ssot-api-staging.an.r.appspot.com/feeds/recent",
+        needAuth = true
+    ).toFeedList()
 }
 
 fun FeedsResponse.toFeedList() =

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/NetworkService.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/NetworkService.kt
@@ -11,32 +11,38 @@ class NetworkService(val httpClient: HttpClient, val authApi: AuthApi) {
     suspend inline fun <reified T : Any> get(
         url: String,
         needAuth: Boolean = false,
-    ): T {
+    ): T = try {
         if (needAuth) {
             authApi.authIfNeeded()
         }
-        return httpClient.get(url)
+        httpClient.get(url)
+    } catch (e: Throwable) {
+        throw e.toAppError()
     }
 
     suspend inline fun <reified T> post(
         urlString: String,
         needAuth: Boolean = false,
         block: HttpRequestBuilder.() -> Unit = {},
-    ): T {
+    ): T = try {
         if (needAuth) {
             authApi.authIfNeeded()
         }
-        return httpClient.post(urlString, block)
+        httpClient.post(urlString, block)
+    } catch (e: Throwable) {
+        throw e.toAppError()
     }
 
     suspend inline fun <reified T> put(
         urlString: String,
         needAuth: Boolean = false,
         block: HttpRequestBuilder.() -> Unit = {},
-    ): T {
+    ): T = try {
         if (needAuth) {
             authApi.authIfNeeded()
         }
-        return httpClient.put(urlString, block)
+        httpClient.put(urlString, block)
+    } catch (e: Throwable) {
+        throw e.toAppError()
     }
 }


### PR DESCRIPTION
## Issue
- close #362 

## Overview (Required)
- map Throwable occued by HttpClient to AppError by calling toAppError in NetworkService
- not to map exceptions on KtorFeedApi class.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
