### PR TITLE
Java 8+ API desugaring support

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # Currently, no API 30 virtual image
-        api-level: [21, 22, 23, 24, 25, 26, 27, 28, 29]
+        api-level: [21, 23, 26, 29]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -11,9 +11,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # Currently, lower terminals fail. ref: https://github.com/Kotlin/kotlinx-datetime#using-in-your-projects
         # Currently, no API 30 virtual image
-        api-level: [26, 27, 28, 29]
+        api-level: [21, 22, 23, 24, 25, 26, 27, 28, 29]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,7 @@ android {
         }
     }
     compileOptions {
+        coreLibraryDesugaringEnabled true // https://github.com/DroidKaigi/conference-app-2021/issues/373
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -98,6 +99,9 @@ hilt {
 dependencies {
     implementation project(':data:repository')
     implementation project(':uicomponent-compose:main')
+
+    // Java 8+ API desugaring support
+    coreLibraryDesugaring Dep.desugarJdkLibs
 
     // Hilt
     implementation Dep.Dagger.hiltAndroid

--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -133,4 +133,6 @@ object Dep {
         const val networkPlugin = "com.facebook.flipper:flipper-network-plugin:0.76.0"
         const val soLoader = "com.facebook.soloader:soloader:0.10.1"
     }
+
+    const val desugarJdkLibs = "com.android.tools:desugar_jdk_libs:1.1.5"
 }

--- a/uicomponent-compose/core/build.gradle
+++ b/uicomponent-compose/core/build.gradle
@@ -11,6 +11,7 @@ apply from: rootProject.file("gradle/android.gradle")
 
 android {
     compileOptions {
+        coreLibraryDesugaringEnabled true // need for test. https://github.com/DroidKaigi/conference-app-2021/issues/373
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -37,6 +38,10 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 
 dependencies {
     api project(":model")
+
+    // Java 8+ API desugaring support
+    coreLibraryDesugaring Dep.desugarJdkLibs
+
     implementation Dep.Kotlin.bom
     implementation Dep.Kotlin.stdlibJdk8
 

--- a/uicomponent-compose/feed/build.gradle
+++ b/uicomponent-compose/feed/build.gradle
@@ -14,6 +14,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
+        coreLibraryDesugaringEnabled true // need for test. https://github.com/DroidKaigi/conference-app-2021/issues/373
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -46,6 +47,9 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 dependencies {
     api project(":uicomponent-compose:core")
     api project(":model")
+
+    // Java 8+ API desugaring support
+    coreLibraryDesugaring Dep.desugarJdkLibs
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation Dep.Accompanist.coil

--- a/uicomponent-compose/main/build.gradle
+++ b/uicomponent-compose/main/build.gradle
@@ -13,6 +13,7 @@ apply from: rootProject.file("gradle/android.gradle")
 
 android {
     compileOptions {
+        coreLibraryDesugaringEnabled true // need for test. https://github.com/DroidKaigi/conference-app-2021/issues/373
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -42,6 +43,9 @@ dependencies {
     api project(":uicomponent-compose:feed")
     api project(":uicomponent-compose:other")
     api project(":model")
+
+    // Java 8+ API desugaring support
+    coreLibraryDesugaring Dep.desugarJdkLibs
 
     // Hilt
     implementation Dep.Dagger.hiltAndroid

--- a/uicomponent-compose/other/build.gradle
+++ b/uicomponent-compose/other/build.gradle
@@ -15,6 +15,7 @@ android {
         resValue "string", "app_version_name", AppVersions.versionName
     }
     compileOptions {
+        coreLibraryDesugaringEnabled true // need for test. https://github.com/DroidKaigi/conference-app-2021/issues/373
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -43,6 +44,9 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 dependencies {
     api project(":uicomponent-compose:core")
     api project(":model")
+
+    // Java 8+ API desugaring support
+    coreLibraryDesugaring Dep.desugarJdkLibs
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation Dep.Accompanist.coil


### PR DESCRIPTION
## Issue
- close #373 

## Overview (Required)
- Add Java 8+ API desugaring support for low API level terminals

## Links
- Related document
	- https://github.com/Kotlin/kotlinx-datetime#using-in-your-projects
	- https://developer.android.com/studio/write/java8-support#library-desugaring

## Screenshot
