### PR TITLE
[Proposal]Replace route screen with pager

### DIFF
--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -93,6 +93,8 @@ object Dep {
     object Accompanist {
         const val insets = "com.google.accompanist:accompanist-insets:0.7.0"
         const val coil = "com.google.accompanist:accompanist-coil:0.7.0"
+        const val pager = "com.google.accompanist:accompanist-pager:0.7.0"
+        const val pagerIndicators = "com.google.accompanist:accompanist-pager-indicators:0.7.0"
     }
 
     object FirebaseCrashlytics {

--- a/uicomponent-compose/feed/build.gradle
+++ b/uicomponent-compose/feed/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation Dep.Accompanist.coil
     implementation Dep.Accompanist.insets
+    implementation Dep.Accompanist.pager
+    implementation Dep.Accompanist.pagerIndicators
 
     implementation Dep.Coroutines.core
 

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -215,7 +215,7 @@ private fun FeedScreen(
                         feedTab = selectedTab,
                         onClickFeed = onClickFeed,
                         onFavoriteChange = onFavoriteChange,
-                        listState = selectedTab.listState,
+                        lazyListState = selectedTab.listState,
                         onClickPlayPodcastButton = onClickPlayPodcastButton,
                         isRevealed = scaffoldState.isRevealed,
                     )
@@ -289,9 +289,10 @@ private fun FeedList(
     onClickFeed: (FeedItem) -> Unit,
     onFavoriteChange: (FeedItem) -> Unit,
     onClickPlayPodcastButton: (FeedItem.Podcast) -> Unit,
-    listState: LazyListState,
+    lazyListState: LazyListState,
     isRevealed: Boolean,
 ) {
+    val listState = remember { lazyListState }
     val isHome = feedTab is FeedTab.Home
     Surface(
         color = MaterialTheme.colors.background,

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -418,6 +418,7 @@ fun RobotItem(
     }
 }
 
+// ref : https://google.github.io/accompanist/pager/#integration-with-tabs
 @OptIn(ExperimentalPagerApi::class)
 fun Modifier.pagerTabIndicatorOffset(
     pagerState: PagerState,

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -69,8 +69,8 @@ import io.github.droidkaigi.feeder.core.theme.AppThemeWithBackground
 import io.github.droidkaigi.feeder.core.theme.greenDroid
 import io.github.droidkaigi.feeder.core.use
 import io.github.droidkaigi.feeder.core.util.collectInLaunchedEffect
-import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
+import kotlinx.coroutines.launch
 
 sealed class FeedTab(val name: String, val routePath: String) {
     object Home : FeedTab("Home", "home")

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -142,7 +142,7 @@ fun FeedScreen(
         }
     }
     val tabLazyListStates = FeedTab.values()
-        .map {it to rememberLazyListState()}
+        .map { it to rememberLazyListState() }
         .toMap()
 
     FeedScreen(

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -293,19 +293,6 @@ private fun FeedList(
     isRevealed: Boolean,
 ) {
     val isHome = feedTab is FeedTab.Home
-    val isListFinished by remember {
-        derivedStateOf {
-            listState.firstVisibleItemIndex + listState.layoutInfo
-                .visibleItemsInfo.size == listState.layoutInfo.totalItemsCount
-        }
-    }
-    val robotAnimValue by animateFloatAsState(
-        targetValue = if (isListFinished) 0f else 10f,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioHighBouncy,
-            stiffness = Spring.StiffnessMedium,
-        )
-    )
     Surface(
         color = MaterialTheme.colors.background,
         modifier = Modifier.fillMaxSize()
@@ -344,6 +331,19 @@ private fun FeedList(
             }
             if (listState.firstVisibleItemIndex != 0) {
                 item {
+                    val isListFinished by remember {
+                        derivedStateOf {
+                            listState.firstVisibleItemIndex + listState.layoutInfo
+                                .visibleItemsInfo.size == listState.layoutInfo.totalItemsCount
+                        }
+                    }
+                    val robotAnimValue by animateFloatAsState(
+                        targetValue = if (isListFinished) 0f else 10f,
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioHighBouncy,
+                            stiffness = Spring.StiffnessMedium,
+                        )
+                    )
                     RobotItem(
                         robotText = "Finished!",
                         robotIcon = painterResource(id = R.drawable.ic_android_green_24dp),

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -313,7 +313,7 @@ private fun FeedList(
         LazyColumn(
             contentPadding = LocalWindowInsets.current.systemBars
                 .toPaddingValues(top = false, start = false, end = false),
-            state = feedTab.listState
+            state = listState
         ) {
             itemsIndexed(feedContents.contents) { index, content ->
                 if (isHome && index == 0) {


### PR DESCRIPTION
## Issue
- 

## Overview (Required)
- Try replacing it with Accompanist's Pager.

## Links
- https://google.github.io/accompanist/pager/

## Screenshot

- Switching tabs by swipe

https://user-images.githubusercontent.com/13705006/113381880-0d863a00-93bb-11eb-9029-04dc2ce4d723.mp4

- Scroll to top when tab is taped

https://user-images.githubusercontent.com/13705006/113381890-1545de80-93bb-11eb-8ab5-380ae92e86d3.mp4

- Show animation when the scroll reaches the bottom

https://user-images.githubusercontent.com/13705006/113381892-15de7500-93bb-11eb-9653-af09c02c8f8a.mp4


