### PR TITLE
Add statusBarsPadding on AppContent

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
@@ -52,7 +51,6 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.navigationBarsPadding
-import com.google.accompanist.insets.statusBarsPadding
 import com.google.accompanist.insets.toPaddingValues
 import io.github.droidkaigi.feeder.FeedContents
 import io.github.droidkaigi.feeder.FeedItem
@@ -215,7 +213,6 @@ private fun FeedScreen(
     isListFinished: MutableState<Boolean>,
 ) {
     Column {
-        val density = LocalDensity.current
         BackdropScaffold(
             backLayerBackgroundColor = MaterialTheme.colors.primarySurface,
             scaffoldState = scaffoldState,
@@ -223,7 +220,7 @@ private fun FeedScreen(
                 BackLayerContent(filters, onFavoriteFilterChanged)
             },
             frontLayerShape = MaterialTheme.shapes.large,
-            peekHeight = 104.dp + (LocalWindowInsets.current.systemBars.top / density.density).dp,
+            peekHeight = 104.dp,
             appBar = {
                 AppBar(onNavigationIconClick, selectedTab, onSelectTab)
             },
@@ -278,7 +275,6 @@ private fun AppBar(
     onSelectTab: (FeedTab) -> Unit,
 ) {
     TopAppBar(
-        modifier = Modifier.statusBarsPadding(),
         title = { Image(painterResource(R.drawable.toolbar_droidkaigi_logo), "DroidKaigi") },
         elevation = 0.dp,
         navigationIcon = {

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DrawerContent.kt
@@ -139,7 +139,7 @@ fun DrawerContent(
     onNavigate: (contents: DrawerContents) -> Unit,
 ) {
     Column {
-        Spacer(modifier = Modifier.height(52.dp))
+        Spacer(modifier = Modifier.height(20.dp))
         Row(
             horizontalArrangement = Arrangement.Start,
             verticalAlignment = Alignment.CenterVertically,

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DroidKaigiApp.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/DroidKaigiApp.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import com.google.accompanist.insets.navigationBarsPadding
+import com.google.accompanist.insets.statusBarsPadding
 import io.github.droidkaigi.feeder.core.theme.ConferenceAppFeederTheme
 import io.github.droidkaigi.feeder.core.use
 
@@ -46,6 +47,7 @@ fun DroidKaigiApp(firstSplashScreenState: SplashState = SplashState.Shown) {
             modifier = Modifier
                 .alpha(contentAlpha)
                 .navigationBarsPadding(bottom = false)
+                .statusBarsPadding()
         )
     }
 }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/other/OtherScreen.kt
@@ -20,12 +20,9 @@ import androidx.compose.material.primarySurface
 import androidx.compose.material.rememberBackdropScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.insets.LocalWindowInsets
-import com.google.accompanist.insets.statusBarsPadding
 import io.github.droidkaigi.feeder.Contributor
 import io.github.droidkaigi.feeder.Staff
 import io.github.droidkaigi.feeder.about.AboutThisApp
@@ -90,7 +87,6 @@ fun OtherScreen(
     onPrivacyPolicyClick: (String) -> Unit,
 ) {
     Column {
-        val density = LocalDensity.current
         BackdropScaffold(
             gesturesEnabled = false,
             backLayerBackgroundColor = MaterialTheme.colors.primarySurface,
@@ -99,7 +95,7 @@ fun OtherScreen(
                 Box(modifier = Modifier.height(1.dp))
             },
             frontLayerShape = MaterialTheme.shapes.large,
-            peekHeight = 104.dp + (LocalWindowInsets.current.systemBars.top / density.density).dp,
+            peekHeight = 104.dp,
             appBar = {
                 AppBar(onNavigationIconClick, selectedTab, onSelectTab)
             },
@@ -126,7 +122,6 @@ private fun AppBar(
     onSelectTab: (OtherTab) -> Unit,
 ) {
     TopAppBar(
-        modifier = Modifier.statusBarsPadding(),
         title = { Image(painterResource(R.drawable.toolbar_droidkaigi_logo), "DroidKaigi") },
         elevation = 0.dp,
         navigationIcon = {


### PR DESCRIPTION
## Issue

- close #230

## Overview (Required)

- Add `statusBarsPadding` on AppContent to avoid overlying status bar on app

If my solution about "switch status bar transparent when navigation drawer open" is not correct, please let me know.

## Links

## Screenshot

### Light

View | Before | After
:--: | :--: | :--:
Top | <img width=300 src="https://user-images.githubusercontent.com/3108110/114155033-fcf63680-995b-11eb-9937-60befce50d29.jpg"> | <img width=300 src="https://user-images.githubusercontent.com/3108110/114155128-1b5c3200-995c-11eb-8191-488f1a2046ca.jpg">
Drawer | <img width=300 src="https://user-images.githubusercontent.com/3108110/114155060-0384ae00-995c-11eb-9846-db66ba9be551.jpg"> | <img width=300 src="https://user-images.githubusercontent.com/3108110/114155139-1e572280-995c-11eb-8052-88c8cc558813.jpg">

### Dark

View | Before | After
:--: | :--: | :--:
Top | <img width=300 src="https://user-images.githubusercontent.com/3108110/114154972-ee0f8400-995b-11eb-9a0f-7f313fb61755.jpg"> | <img width=300 src="https://user-images.githubusercontent.com/3108110/114155201-2dd66b80-995c-11eb-8270-ed53bd5251b5.jpg">
Drawer | <img width=300 src="https://user-images.githubusercontent.com/3108110/114154980-f071de00-995b-11eb-9c72-37d6e2b1df98.jpg"> | <img width=300 src="https://user-images.githubusercontent.com/3108110/114155210-3038c580-995c-11eb-8799-61b6e19ce8bb.jpg">

