### PR TITLE
Make it possible to reference the types of imported modules in iOS

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,5 @@ android.enableJetifier=true
 kotlin.code.style=official
 # hierarchy structure support
 # https://kotlinlang.org/docs/mpp-share-on-platforms.html#share-code-on-similar-platforms
-# This will cause sync issue. Probably libraries not supported
-# kotlin.mpp.enableGranularSourceSetsMetadata=true
-# kotlin.native.enableDependencyPropagation=false
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- now, IOS code cannot resolve the type of imported modules.
- For example, `db` module cannot resolve the type of the `model` module.
- It happens only in the IDE display. We can build from the command line.

I restored the flag in `gradle.properties`.

I've had success with sync in my environment.
I don't fully understand these issues.
However, I think that maybe the flag in `gradle.properties` is necessary.

## Links
- https://kotlinlang.org/docs/migrating-multiplatform-project-to-14.html#try-the-hierarchical-project-structure

## Screenshot
🙅‍♂️