### PR TITLE
when feed is filtered, show item count even if filter parts is closed

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -221,7 +221,7 @@ private fun FeedScreen(
                         onFavoriteChange = onFavoriteChange,
                         listState = tabLazyListStates.getValue(selectedTab),
                         onClickPlayPodcastButton = onClickPlayPodcastButton,
-                        isRevealed = scaffoldState.isRevealed,
+                        showItemCount = scaffoldState.isRevealed || filters.filterFavorite,
                     )
                 }
             },
@@ -295,7 +295,7 @@ private fun FeedList(
     onFavoriteChange: (FeedItem) -> Unit,
     onClickPlayPodcastButton: (FeedItem.Podcast) -> Unit,
     listState: LazyListState,
-    isRevealed: Boolean,
+    showItemCount: Boolean,
 ) {
     val isHome = feedTab is FeedTab.Home
     Surface(
@@ -309,7 +309,7 @@ private fun FeedList(
         ) {
             itemsIndexed(feedContents.contents) { index, content ->
                 if (isHome && index == 0) {
-                    if (isRevealed) {
+                    if (showItemCount) {
                         FilterItemCountRow(feedContents.size.toString())
                     }
                     FirstFeedItem(

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -221,7 +221,7 @@ private fun FeedScreen(
                         onFavoriteChange = onFavoriteChange,
                         listState = tabLazyListStates.getValue(selectedTab),
                         onClickPlayPodcastButton = onClickPlayPodcastButton,
-                        showItemCount = scaffoldState.isRevealed || filters.filterFavorite,
+                        showItemCount = filters.filterFavorite,
                     )
                 }
             },


### PR DESCRIPTION
## Issue
- close #413

## Overview (Required)
- As said as title, show item count on following situations.
  - feed is filtered
  - filter is opened
- if feed is not filtered and filter is closed, item count is not displayed.

## Links
-

## Record
https://user-images.githubusercontent.com/74723074/115142279-d763de00-a07b-11eb-9d52-ce74cebafe10.mp4

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
