### PR TITLE
Add padding to image when FeedList is in filter-state on Home Tab.

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -221,7 +221,7 @@ private fun FeedScreen(
                         onFavoriteChange = onFavoriteChange,
                         listState = tabLazyListStates.getValue(selectedTab),
                         onClickPlayPodcastButton = onClickPlayPodcastButton,
-                        showItemCount = filters.filterFavorite,
+                        isFilterState = filters.filterFavorite,
                     )
                 }
             },
@@ -295,7 +295,7 @@ private fun FeedList(
     onFavoriteChange: (FeedItem) -> Unit,
     onClickPlayPodcastButton: (FeedItem.Podcast) -> Unit,
     listState: LazyListState,
-    showItemCount: Boolean,
+    isFilterState: Boolean,
 ) {
     val isHome = feedTab is FeedTab.Home
     Surface(
@@ -309,7 +309,7 @@ private fun FeedList(
         ) {
             itemsIndexed(feedContents.contents) { index, content ->
                 if (isHome && index == 0) {
-                    if (showItemCount) {
+                    if (isFilterState) {
                         FilterItemCountRow(feedContents.size.toString())
                     }
                     FirstFeedItem(
@@ -317,7 +317,8 @@ private fun FeedList(
                         favorited = content.second,
                         onClick = onClickFeed,
                         showMediaLabel = isHome,
-                        onFavoriteChange = onFavoriteChange
+                        onFavoriteChange = onFavoriteChange,
+                        shouldPadding = isFilterState
                     )
                 } else {
                     FeedItemRow(

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FirstFeedItem.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FirstFeedItem.kt
@@ -37,6 +37,7 @@ fun FirstFeedItem(
     showMediaLabel: Boolean = false,
     onClick: (FeedItem) -> Unit,
     onFavoriteChange: (FeedItem) -> Unit,
+    shouldPadding: Boolean
 ) {
     ConstraintLayout(
         modifier = Modifier
@@ -47,6 +48,8 @@ fun FirstFeedItem(
             .semantics(mergeDescendants = true) { }
     ) {
         val (image, title, media, date, favorite, favoriteAnim) = createRefs()
+        val horizontalPadding = if (shouldPadding) 20.dp else 0.dp
+        val verticalPadding = if (shouldPadding) 48.dp else 0.dp
         NetworkImage(
             url = feedItem.image.standardUrl,
             modifier = Modifier
@@ -55,6 +58,11 @@ fun FirstFeedItem(
                     start.linkTo(parent.start)
                     end.linkTo(parent.end)
                 }
+                .padding(
+                    start = horizontalPadding,
+                    end = horizontalPadding,
+                    top = verticalPadding
+                )
                 .wrapContentWidth()
                 .aspectRatio(16F / 9F),
             contentScale = ContentScale.Crop,
@@ -168,7 +176,8 @@ fun PreviewFirstFeedItem() {
             favorited = false,
             showMediaLabel = false,
             onClick = { },
-            onFavoriteChange = { }
+            onFavoriteChange = { },
+            shouldPadding = false
         )
     }
 }
@@ -183,7 +192,24 @@ fun PreviewFirstFeedItemWithMedia() {
             favorited = false,
             showMediaLabel = true,
             onClick = { },
-            onFavoriteChange = { }
+            onFavoriteChange = { },
+            shouldPadding = false
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewFirstFeedItemWithFiltered() {
+    ConferenceAppFeederTheme {
+        val feedItem = fakeFeedContents().feedItemContents[0]
+        FirstFeedItem(
+            feedItem = feedItem,
+            favorited = false,
+            showMediaLabel = true,
+            onClick = { },
+            onFavoriteChange = { },
+            shouldPadding = true
         )
     }
 }


### PR DESCRIPTION
## Issue
- close #414 

## Overview (Required)
- Add padding to Image of FirstFeedItem which is filtered.
- Conform with design on [figma](https://www.figma.com/file/IFlrbfmBSdYvUz7VmSzfLV/DroidKaigi_2021_official_app?node-id=1516%3A423).

## Links
- https://www.figma.com/file/IFlrbfmBSdYvUz7VmSzfLV/DroidKaigi_2021_official_app?node-id=1516%3A423

## Screenshot

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/44002126/116512335-d5fba680-a902-11eb-9bea-5737983df97c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/44002126/116512324-d431e300-a902-11eb-80a8-90fc3c654cc0.png" width="300" />
