### PR TITLE
Use resolutionStrategy for align version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import io.github.droidkaigi.feeder.Dep
+import io.github.droidkaigi.feeder.Versions
 
 buildscript {
     ext {
@@ -30,6 +31,17 @@ buildscript {
         classpath 'app.cash.exhaustive:exhaustive-gradle:0.1.1'
         classpath Dep.SQLDelight.plugin
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.4'
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            eachDependency { details ->
+                if (details.requested.group == "org.jetbrains.kotlinx" &&
+                        details.requested.name.contains("kotlinx-coroutines")) {
+                    details.useVersion Versions.coroutines
+                }
+            }
+        }
     }
 }
 

--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -40,11 +40,6 @@ kotlin {
             implementation project(":data:db")
 
             implementation Dep.Ktor.bom
-            implementation (Dep.Coroutines.core) {
-                version {
-                    strictly Versions.coroutines
-                }
-            }
             implementation Dep.Ktor.json
             implementation Dep.Ktor.serialization
             implementation Dep.Ktor.logging

--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -1,5 +1,4 @@
 import io.github.droidkaigi.feeder.Dep
-import io.github.droidkaigi.feeder.Versions
 
 plugins {
     id("kotlin-multiplatform")

--- a/data/db/build.gradle
+++ b/data/db/build.gradle
@@ -1,5 +1,4 @@
 import io.github.droidkaigi.feeder.Dep
-import io.github.droidkaigi.feeder.Versions
 
 plugins {
     id("kotlin-multiplatform")

--- a/data/db/build.gradle
+++ b/data/db/build.gradle
@@ -40,11 +40,6 @@ kotlin {
             api project(":model")
 
             implementation Dep.Coroutines.bom
-            implementation (Dep.Coroutines.core) {
-                version {
-                    strictly Versions.coroutines
-                }
-            }
 
             implementation Dep.Serialization.core
             implementation Dep.MultiplatformSettings.settings

--- a/data/repository/build.gradle
+++ b/data/repository/build.gradle
@@ -1,5 +1,4 @@
 import io.github.droidkaigi.feeder.Dep
-import io.github.droidkaigi.feeder.Versions
 
 plugins {
     id("kotlin-multiplatform")

--- a/data/repository/build.gradle
+++ b/data/repository/build.gradle
@@ -41,11 +41,6 @@ kotlin {
             api project(":data:db")
 
             implementation Dep.Coroutines.bom
-            implementation (Dep.Coroutines.core) {
-                version {
-                    strictly Versions.coroutines
-                }
-            }
         }
         commonTest.dependencies {
             implementation Dep.KotlinTest.common

--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import io.github.droidkaigi.feeder.Dep
-import io.github.droidkaigi.feeder.Versions
 
 plugins {
     kotlin("multiplatform")
@@ -38,11 +37,7 @@ kotlin {
                 api(project(":data:repository"))
 
                 implementation(Dep.Coroutines.bom)
-                implementation(Dep.Coroutines.core) {
-                    version {
-                        strictly(Versions.coroutines)
-                    }
-                }
+                implementation(Dep.Coroutines.core)
             }
         }
         val commonTest by getting {

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -15,11 +15,7 @@ kotlin {
         android
         commonMain.dependencies {
             api project.dependencies.platform(Dep.Coroutines.bom)
-            api (Dep.Coroutines.core) {
-                version {
-                    strictly Versions.coroutines
-                }
-            }
+            api Dep.Coroutines.core
             api Dep.datetime
         }
         android {}

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,5 +1,4 @@
 import io.github.droidkaigi.feeder.Dep
-import io.github.droidkaigi.feeder.Versions
 
 plugins {
     id("com.android.library")


### PR DESCRIPTION
## Overview (Required)

```diff
0a1
> Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details
20a22,25
> > Configure project :
> kotlinx-coroutines-core
> kotlinx-coroutines-core-jvm
> 
479c484
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt (*)
1138c1143
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt (*)
1668c1673
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt (*)
2251c2256
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt (*)
2416d2420
< |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
2451d2454
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
2484,2485c2487
< |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2-native-mt (*)
< |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2-native-mt (*)
2932c2934
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt (*)
3908c3910
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt (*)
4073d4074
< |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
4108d4108
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
4141,4142c4141
< |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2-native-mt (*)
< |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2-native-mt (*)
4546c4545
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt
5779c5778
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt
6278c6277
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt
6709c6708
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt
6882d6880
< |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
6917d6914
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
6950,6951c6947
< |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2-native-mt (*)
< |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2-native-mt (*)
7507c7503
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt
8329c8325
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core -> 1.4.2-native-mt (*)
8499d8494
< |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
8534d8528
< |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
8567,8568c8561
< |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2-native-mt (*)
< |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.4.2-native-mt} -> 1.4.2-native-mt (*)
---
> |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.4.2-native-mt (*)
9320c9313
< BUILD SUCCESSFUL in 7s
---
> BUILD SUCCESSFUL in 15s

```

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
