### PR TITLE
Change status bar color behavior

### DIFF
--- a/android/src/main/res/values/themes.xml
+++ b/android/src/main/res/values/themes.xml
@@ -9,9 +9,7 @@
         <item name="colorSecondary">@color/green_200</item>
         <item name="colorOnSecondary">@color/black</item>
 
-        <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
     <style name="Theme.ConferenceAppFeeder.NoActionBar">

--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -96,6 +96,7 @@ object Dep {
         const val coil = "com.google.accompanist:accompanist-coil:0.8.1"
         const val pager = "com.google.accompanist:accompanist-pager:0.8.1"
         const val pagerIndicators = "com.google.accompanist:accompanist-pager-indicators:0.8.1"
+        const val systemuicontroller = "com.google.accompanist:accompanist-systemuicontroller:0.8.1"
     }
 
     object FirebaseCrashlytics {

--- a/uicomponent-compose/main/build.gradle
+++ b/uicomponent-compose/main/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation Dep.Accompanist.coil
     implementation Dep.Accompanist.insets
+    implementation Dep.Accompanist.systemuicontroller
 
     implementation (Dep.Coroutines.core) {
         version {

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -22,6 +22,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navArgument
 import androidx.navigation.compose.navigate
 import androidx.navigation.navDeepLink
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import io.github.droidkaigi.feeder.core.navigation.chromeCustomTabs
 import io.github.droidkaigi.feeder.core.navigation.navigateChromeCustomTabs
 import io.github.droidkaigi.feeder.core.navigation.rememberCustomNavController
@@ -35,16 +36,27 @@ import kotlinx.coroutines.launch
 private const val FEED_PATH = "feed/"
 private const val OTHER_PATH = "other/"
 
+private val drawerOpenedStatusBarColor = Color.Black.copy(alpha = 0.48f)
+
 @Composable
 fun AppContent(
     modifier: Modifier = Modifier,
     firstDrawerValue: DrawerValue = DrawerValue.Closed,
 ) {
-    val drawerState = rememberDrawerState(firstDrawerValue)
+    val systemUiController = rememberSystemUiController()
+    val drawerState = rememberDrawerState(firstDrawerValue) {
+        if (it == DrawerValue.Closed) {
+            systemUiController.setStatusBarColor(Color.Transparent)
+        } else {
+            systemUiController.setStatusBarColor(drawerOpenedStatusBarColor)
+        }
+        true
+    }
     val drawerContentState = rememberDrawerContentState(DrawerContents.HOME.route)
     val navController = rememberCustomNavController()
     val coroutineScope = rememberCoroutineScope()
     val onNavigationIconClick: () -> Unit = {
+        systemUiController.setStatusBarColor(drawerOpenedStatusBarColor)
         coroutineScope.launch {
             drawerState.open()
         }
@@ -64,6 +76,7 @@ fun AppContent(
                 if (drawerContentState.selectDrawerContent(contents.route)) {
                     actions.onSelectDrawerItem(contents)
                 }
+                systemUiController.setStatusBarColor(Color.Transparent)
                 coroutineScope.launch {
                     drawerState.close()
                 }

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/AppContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalDrawer
 import androidx.compose.material.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -44,19 +45,18 @@ fun AppContent(
     firstDrawerValue: DrawerValue = DrawerValue.Closed,
 ) {
     val systemUiController = rememberSystemUiController()
-    val drawerState = rememberDrawerState(firstDrawerValue) {
-        if (it == DrawerValue.Closed) {
+    val drawerState = rememberDrawerState(firstDrawerValue)
+    LaunchedEffect(drawerState.currentValue) {
+        if (drawerState.currentValue == DrawerValue.Closed) {
             systemUiController.setStatusBarColor(Color.Transparent)
         } else {
             systemUiController.setStatusBarColor(drawerOpenedStatusBarColor)
         }
-        true
     }
     val drawerContentState = rememberDrawerContentState(DrawerContents.HOME.route)
     val navController = rememberCustomNavController()
     val coroutineScope = rememberCoroutineScope()
     val onNavigationIconClick: () -> Unit = {
-        systemUiController.setStatusBarColor(drawerOpenedStatusBarColor)
         coroutineScope.launch {
             drawerState.open()
         }
@@ -76,7 +76,6 @@ fun AppContent(
                 if (drawerContentState.selectDrawerContent(contents.route)) {
                     actions.onSelectDrawerItem(contents)
                 }
-                systemUiController.setStatusBarColor(Color.Transparent)
                 coroutineScope.launch {
                     drawerState.close()
                 }


### PR DESCRIPTION
## Issue

- close #230

## Overview (Required)

- Add [accompanist-systemuicontroller](https://google.github.io/accompanist/systemuicontroller/) dependency
- Change status bar color
  - default: transparent
  - drawer opened: semi-transparent
  - drawer closed: transparent

### Note

~~I found bug in this pull request that status bar color does not change when drawer is closed by touching outside drawer.~~
~~It's difficult for me to fix this bug. But, I think this is resolved by jetpack compose update in the future. Because same bug issue has been reported by google [issue tracker](https://issuetracker.google.com/issues/181387076).~~

above bug is fixed by 6d07621

## Links


## Screenshot

### Light

View | Before | After
:--: | :--: | :--:
Top | <img width=300 src="https://user-images.githubusercontent.com/3108110/116660643-491e1f00-a9ce-11eb-8b3e-11f086a27b4c.jpeg"> | <img width=300 src="https://user-images.githubusercontent.com/3108110/116658881-a4024700-a9cb-11eb-87c3-47daf95fcabe.png">
Drawer | <img width=300 src="https://user-images.githubusercontent.com/3108110/116660646-491e1f00-a9ce-11eb-970b-756184d7a6ce.jpeg"> | <img width=300 src="https://user-images.githubusercontent.com/3108110/116658885-a5337400-a9cb-11eb-93c9-05bf6ad0b50d.png">

### Dark

View | Before | After
:--: | :--: | :--:
Top | <img width=300 src="https://user-images.githubusercontent.com/3108110/116660637-47ecf200-a9ce-11eb-8b23-5f7f1d3335bd.jpeg"> | <img width=300 src="https://user-images.githubusercontent.com/3108110/116658886-a664a100-a9cb-11eb-894a-72344af15360.png">
Drawer | <img width=300 src="https://user-images.githubusercontent.com/3108110/116660641-48858880-a9ce-11eb-9c0d-a919aea6035e.jpeg"> | <img width=300 src="https://user-images.githubusercontent.com/3108110/116658888-a6fd3780-a9cb-11eb-8a0c-37b8b95a457d.png">


