### PR TITLE
Changed to use pagerTabIndicatorOffset provided by library

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -276,7 +276,7 @@ private fun AppBar(
                         tabLazyListStates.getValue(tab).animateScrollToItem(index = 0)
                     }
                 },
-                // To overwrite the indicator
+                // For tabs to draw in front of indicators
                 modifier = Modifier.zIndex(1f)
             )
         }

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -276,6 +276,7 @@ private fun AppBar(
                         tabLazyListStates.getValue(tab).animateScrollToItem(index = 0)
                     }
                 },
+                // To overwrite the indicator
                 modifier = Modifier.zIndex(1f)
             )
         }

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -22,6 +20,7 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ScrollableTabRow
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.SnackbarResult
 import androidx.compose.material.Surface
@@ -36,9 +35,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
@@ -48,7 +45,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.lerp
+import androidx.compose.ui.zIndex
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.google.accompanist.insets.LocalWindowInsets
 import com.google.accompanist.insets.navigationBarsPadding
@@ -57,14 +54,13 @@ import com.google.accompanist.insets.toPaddingValues
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
+import com.google.accompanist.pager.pagerTabIndicatorOffset
 import com.google.accompanist.pager.rememberPagerState
 import io.github.droidkaigi.feeder.FeedContents
 import io.github.droidkaigi.feeder.FeedItem
 import io.github.droidkaigi.feeder.Filters
 import io.github.droidkaigi.feeder.Theme
-import io.github.droidkaigi.feeder.core.ScrollableTabRow
 import io.github.droidkaigi.feeder.core.TabIndicator
-import io.github.droidkaigi.feeder.core.TabPosition
 import io.github.droidkaigi.feeder.core.getReadableMessage
 import io.github.droidkaigi.feeder.core.theme.AppThemeWithBackground
 import io.github.droidkaigi.feeder.core.theme.greenDroid
@@ -257,8 +253,7 @@ private fun AppBar(
     ScrollableTabRow(
         selectedTabIndex = 0,
         edgePadding = 0.dp,
-        foregroundIndicator = {},
-        backgroundIndicator = { tabPositions ->
+        indicator = { tabPositions ->
             TabIndicator(
                 modifier = Modifier.pagerTabIndicatorOffset(pagerState, tabPositions)
             )
@@ -280,7 +275,8 @@ private fun AppBar(
                         pagerState.animateScrollToPage(index)
                         tabLazyListStates.getValue(tab).animateScrollToItem(index = 0)
                     }
-                }
+                },
+                modifier = Modifier.zIndex(1f)
             )
         }
     }
@@ -427,33 +423,6 @@ fun RobotItem(
             tint = robotIconColor
         )
     }
-}
-
-// ref : https://google.github.io/accompanist/pager/#integration-with-tabs
-@OptIn(ExperimentalPagerApi::class)
-fun Modifier.pagerTabIndicatorOffset(
-    pagerState: PagerState,
-    tabPositions: List<TabPosition>,
-): Modifier = composed {
-    val targetIndicatorOffset: Dp
-    val indicatorWidth: Dp
-
-    val currentTab = tabPositions[pagerState.currentPage]
-    val nextTab = tabPositions.getOrNull(pagerState.currentPage + 1)
-    if (nextTab != null) {
-        // If we have a next tab, lerp between the size and offset
-        targetIndicatorOffset = lerp(currentTab.left, nextTab.left, pagerState.currentPageOffset)
-        indicatorWidth = lerp(currentTab.width, nextTab.width, pagerState.currentPageOffset)
-    } else {
-        // Otherwise we just use the current tab/page
-        targetIndicatorOffset = currentTab.left
-        indicatorWidth = currentTab.width
-    }
-
-    fillMaxWidth()
-        .wrapContentSize(Alignment.BottomStart)
-        .offset(x = targetIndicatorOffset)
-        .width(indicatorWidth)
 }
 
 @Composable


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Changed to use `pagerTabIndicatorOffset` provided by Accompanist.  
- Using `zIndex` Modifier eliminates the need for custom `ScrollableTabRow`.  
  - https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#(androidx.compose.ui.Modifier).zIndex(kotlin.Float)

## Links
- https://google.github.io/accompanist/pager/#integration-with-tabs

## Screenshot

https://user-images.githubusercontent.com/13705006/119466443-95ffd600-bd7f-11eb-94e4-cef2e49a1824.mp4


