### PR TITLE
[iOS] Use namespace in xcassets

### DIFF
--- a/ios/Sources/Styleguide/Color.xcassets/Base/Contents.json
+++ b/ios/Sources/Styleguide/Color.xcassets/Base/Contents.json
@@ -2,5 +2,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
   }
 }

--- a/ios/Sources/Styleguide/Color.xcassets/Separate/Contents.json
+++ b/ios/Sources/Styleguide/Color.xcassets/Separate/Contents.json
@@ -2,5 +2,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
   }
 }

--- a/ios/Sources/Styleguide/Color.xcassets/Tag/Contents.json
+++ b/ios/Sources/Styleguide/Color.xcassets/Tag/Contents.json
@@ -2,5 +2,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
   }
 }

--- a/ios/Sources/Styleguide/Color.xcassets/background/Contents.json
+++ b/ios/Sources/Styleguide/Color.xcassets/background/Contents.json
@@ -2,5 +2,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
   }
 }


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Currently, SwiftGen output files can't use color correctly. 
- Use namespace in xcassets.

## Links
-
