### PR TITLE
[iOS] Create Module for Localization and Apply

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -3,6 +3,7 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+.swiftpm
 
 # SwiftGen generated
 Generated/

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 // MARK: - Main Package
 var package = Package(
     name: "DroidKaigi2021Package",
+    defaultLocalization: "ja",
     platforms: [
         .iOS(.v14)
     ],
@@ -78,6 +79,7 @@ var package = Package(
             resources: [
                 .process("Color.xcassets"),
                 .process("Image.xcassets"),
+                .process("Resources"),
             ]
         ),
         .target(

--- a/ios/Sources/AboutFeature/AboutScreen.swift
+++ b/ios/Sources/AboutFeature/AboutScreen.swift
@@ -1,10 +1,11 @@
 import SwiftUI
+import Styleguide
 
 public struct AboutScreen: View {
     public init() {}
 
     public var body: some View {
-        Text("About")
+        Text(L10n.AboutScreen.title)
     }
 }
 

--- a/ios/Sources/AppFeature/AppScreen.swift
+++ b/ios/Sources/AppFeature/AppScreen.swift
@@ -14,13 +14,13 @@ enum AppTab: CaseIterable {
     var title: String {
         switch self {
         case .home:
-            return "Home"
+            return L10n.HomeScreen.title
         case .media:
-            return "Media"
+            return L10n.MediaScreen.title
         case .favorites:
-            return "Favorites"
+            return L10n.FavoriteScreen.title
         case .about:
-            return "About"
+            return L10n.AboutScreen.title
         }
     }
 

--- a/ios/Sources/FavoritesFeature/FavoritesScreen.swift
+++ b/ios/Sources/FavoritesFeature/FavoritesScreen.swift
@@ -1,10 +1,11 @@
 import SwiftUI
+import Styleguide
 
 public struct FavoritesScreen: View {
     public init() {}
 
     public var body: some View {
-        Text("Favorites")
+        Text(L10n.FavoriteScreen.title)
     }
 }
 

--- a/ios/Sources/HomeFeature/HomeScreen.swift
+++ b/ios/Sources/HomeFeature/HomeScreen.swift
@@ -1,10 +1,11 @@
 import SwiftUI
+import Styleguide
 
 public struct HomeScreen: View {
     public init() {}
 
     public var body: some View {
-        Text("Home")
+        Text(L10n.HomeScreen.title)
     }
 }
 

--- a/ios/Sources/MediaFeature/MediaScreen.swift
+++ b/ios/Sources/MediaFeature/MediaScreen.swift
@@ -1,10 +1,11 @@
 import SwiftUI
+import Styleguide
 
 public struct MediaScreen: View {
     public init() {}
 
     public var body: some View {
-        Text("Media")
+        Text(L10n.MediaScreen.title)
     }
 }
 

--- a/ios/Sources/Styleguide/Resources/ja.lproj/Localizable.strings
+++ b/ios/Sources/Styleguide/Resources/ja.lproj/Localizable.strings
@@ -1,5 +1,3 @@
-// MARK: Utility
-
 // MARK: Home
 "HomeScreen.Title" = "Home";
 

--- a/ios/Sources/Styleguide/Resources/ja.lproj/Localizable.strings
+++ b/ios/Sources/Styleguide/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,13 @@
+// MARK: Utility
+
+// MARK: Home
+"HomeScreen.Title" = "Home";
+
+// MARK: Media
+"MediaScreen.Title" = "Media";
+
+// MARK: Favorite
+"FavoriteScreen.Title" = "Favorite";
+
+// MARK: About
+"AboutScreen.Title" = "About";

--- a/ios/swiftgen.yml
+++ b/ios/swiftgen.yml
@@ -1,3 +1,14 @@
+strings:
+  - inputs:
+       - Sources/Styleguide/Resources/ja.lproj/Localizable.strings
+    outputs:
+      templatePath: templates/strings/structured-swift5.stencil
+      output: Sources/Styleguide/Generated/String.swift
+      params:
+        publicAccess: true
+        forceProvidesNamespaces: true
+        bundle: Bundle.myModule
+
 xcassets:
   - inputs: Sources/Styleguide/Image.xcassets
     outputs:

--- a/ios/templates/strings/structured-swift5.stencil
+++ b/ios/templates/strings/structured-swift5.stencil
@@ -1,0 +1,102 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if tables.count > 0 %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import Foundation
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Strings
+
+{% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
+  {% for type in types %}
+    {% if type == "String" %}
+    _ p{{forloop.counter}}: Any
+    {% else %}
+    _ p{{forloop.counter}}: {{type}}
+    {% endif %}
+    {{ ", " if not forloop.last }}
+  {% endfor %}
+{% endfilter %}{% endmacro %}
+{% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
+  {% for type in types %}
+    {% if type == "String" %}
+    String(describing: p{{forloop.counter}})
+    {% elif type == "UnsafeRawPointer" %}
+    Int(bitPattern: p{{forloop.counter}})
+    {% else %}
+    p{{forloop.counter}}
+    {% endif %}
+    {{ ", " if not forloop.last }}
+  {% endfor %}
+{% endfilter %}{% endmacro %}
+{% macro recursiveBlock table item %}
+  {% for string in item.strings %}
+  {% if not param.noComments %}
+  /// {{string.translation}}
+  {% endif %}
+  {% if string.types %}
+  {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {% call argumentsBlock string.types %})
+  }
+  {% elif param.lookupFunction %}
+  {# custom localization function is mostly used for in-app lang selection, so we want the loc to be recomputed at each call for those (hence the computed var) #}
+  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}") }
+  {% else %}
+  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}")
+  {% endif %}
+  {% endfor %}
+  {% for child in item.children %}
+
+  {{accessModifier}} enum {{child.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2 %}{% call recursiveBlock table child %}{% endfilter %}
+  }
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
+{% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
+{{accessModifier}} enum {{enumName}} {
+  {% if tables.count > 1 or param.forceFileNameEnum %}
+  {% for table in tables %}
+  {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call recursiveBlock tables.first.name tables.first.levels %}
+  {% endif %}
+}
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
+
+// MARK: - Implementation Details
+
+extension {{enumName}} {
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
+    {% if param.lookupFunction %}
+    let format = {{ param.lookupFunction }}(key, table)
+    {% else %}
+    let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: nil, table: table)
+    {% endif %}
+    return String(format: format, locale: Locale.current, arguments: args)
+  }
+}
+{% if not param.bundle and not param.lookupFunction %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No string found
+{% endif %}


### PR DESCRIPTION
## Issue
- close #453

## Overview (Required)
I did not create new module for localization because current `Styleguide` module looks good to create `Localizable.strings` in it. So, what I did is just add configuration for SwiftGen strings. Because @ry-itto told me about calling templateName does not work (ref: https://github.com/DroidKaigi/conference-app-2021/pull/443#discussion_r642508006 ), I add stencil file to use as template.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/27538852/120267335-b7604500-c2de-11eb-8519-59fb59aeb29c.png" width="300" />
