### PR TITLE
[iOS] Access color defined in Asset with Color directly

### DIFF
--- a/ios/Sources/Component/Card/LargeCard.swift
+++ b/ios/Sources/Component/Card/LargeCard.swift
@@ -36,7 +36,7 @@ public struct LargeCard: View {
 
                 Text(title)
                     .font(.headline)
-                    .foregroundColor(Color(AssetColor.Base.primary.color))
+                    .foregroundColor(AssetColor.Base.primary.color)
                     .lineLimit(2)
 
                 HStack(spacing: 8) {
@@ -46,7 +46,7 @@ public struct LargeCard: View {
 
                     Text(date.formatted)
                         .font(.caption)
-                        .foregroundColor(Color(AssetColor.Base.tertiary.color))
+                        .foregroundColor(AssetColor.Base.tertiary.color)
 
                     Spacer()
 
@@ -54,12 +54,12 @@ public struct LargeCard: View {
                         let uiImage = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
                         Image(uiImage: uiImage)
                             .renderingMode(.template)
-                            .foregroundColor(Color(AssetColor.primary.color))
+                            .foregroundColor(AssetColor.primary.color)
                     })
                 }
             }
             .padding(16)
-            .background(Color(AssetColor.Background.primary.color))
+            .background(AssetColor.Background.primary.color)
         })
     }
 }

--- a/ios/Sources/Component/Card/MediumCard.swift
+++ b/ios/Sources/Component/Card/MediumCard.swift
@@ -37,12 +37,12 @@ public struct MediumCard: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(title)
                             .font(.subheadline)
-                            .foregroundColor(Color(AssetColor.Base.primary.color))
+                            .foregroundColor(AssetColor.Base.primary.color)
                             .lineLimit(2)
 
                         Text(date.formatted)
                             .font(.caption)
-                            .foregroundColor(Color(AssetColor.Base.tertiary.color))
+                            .foregroundColor(AssetColor.Base.tertiary.color)
                     }
 
                     HStack(spacing: 8) {
@@ -56,13 +56,13 @@ public struct MediumCard: View {
                             let uiImage = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
                             Image(uiImage: uiImage)
                                 .renderingMode(.template)
-                                .foregroundColor(Color(AssetColor.primary.color))
+                                .foregroundColor(AssetColor.primary.color)
                         })
                     }
                 }
             }
             .padding(16)
-            .background(Color(AssetColor.Background.primary.color))
+            .background(AssetColor.Background.primary.color)
         })
     }
 }

--- a/ios/Sources/Component/Card/SmallCard.swift
+++ b/ios/Sources/Component/Card/SmallCard.swift
@@ -38,12 +38,12 @@ public struct SmallCard: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(title)
                             .font(.subheadline)
-                            .foregroundColor(Color(AssetColor.Base.primary.color))
+                            .foregroundColor(AssetColor.Base.primary.color)
                             .lineLimit(2)
 
                         Text(date.formatted)
                             .font(.caption)
-                            .foregroundColor(Color(AssetColor.Base.tertiary.color))
+                            .foregroundColor(AssetColor.Base.tertiary.color)
                     }
 
                     HStack(spacing: 8) {
@@ -57,13 +57,13 @@ public struct SmallCard: View {
                             let uiImage = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
                             Image(uiImage: uiImage)
                                 .renderingMode(.template)
-                                .foregroundColor(Color(AssetColor.primary.color))
+                                .foregroundColor(AssetColor.primary.color)
                         })
                     }
                 }
             }
             .padding(8)
-            .background(Color(AssetColor.Background.primary.color))
+            .background(AssetColor.Background.primary.color)
         })
     }
 }

--- a/ios/Sources/Component/ImageView/ImageView.swift
+++ b/ios/Sources/Component/ImageView/ImageView.swift
@@ -19,11 +19,11 @@ public struct ImageView: View {
     public var body: some View {
         // TODO: add placeholder image
         Image("")
-            .background(Color(AssetColor.Base.secondary.color))
+            .background(AssetColor.Base.secondary.color)
             .frame(width: width, height: height, alignment: .center)
             .overlay(
                 RoundedRectangle(cornerRadius: 2)
-                    .stroke(Color(AssetColor.Separate.image.color), lineWidth: 1)
+                    .stroke(AssetColor.Separate.image.color, lineWidth: 1)
             )
     }
 }

--- a/ios/Sources/Component/MessageBar/MessageBar.swift
+++ b/ios/Sources/Component/MessageBar/MessageBar.swift
@@ -13,10 +13,10 @@ public struct MessageBar: View {
     public var body: some View {
         Text(title)
             .font(.subheadline)
-            .foregroundColor(Color(AssetColor.Base.white.color))
+            .foregroundColor(AssetColor.Base.white.color)
             .padding(.vertical, 8)
             .padding(.horizontal, 12)
-            .background(Color(AssetColor.primaryDark.color))
+            .background(AssetColor.primaryDark.color)
             .cornerRadius(4)
     }
 }

--- a/ios/Sources/Component/Tag/Tag.swift
+++ b/ios/Sources/Component/Tag/Tag.swift
@@ -16,7 +16,7 @@ public struct Tag: View {
     public var body: some View {
         Text(type.title)
             .font(.caption)
-            .foregroundColor(Color(AssetColor.Base.white.color))
+            .foregroundColor(AssetColor.Base.white.color)
             .padding(.vertical, 4)
             .padding(.horizontal, 12)
             .background(type.backgroundColor)
@@ -63,11 +63,11 @@ private extension TagType {
     var backgroundColor: Color {
         switch self {
         case .droidKaigiFm:
-            return Color(AssetColor.secondary.color)
+            return AssetColor.secondary.color
         case .medium:
-            return Color(AssetColor.Tag.medium.color)
+            return AssetColor.Tag.medium.color
         case .youtube:
-            return Color(AssetColor.Tag.video.color)
+            return AssetColor.Tag.video.color
         }
     }
 }

--- a/ios/Sources/HomeFeature/QuestionnaireView.swift
+++ b/ios/Sources/HomeFeature/QuestionnaireView.swift
@@ -13,7 +13,7 @@ public struct QuestionnaireView: View {
             HStack {
                 Image(uiImage: AssetImage.logo.image)
                 Text(L10n.HomeScreen.Questionnaire.title)
-                    .foregroundColor(Color(AssetColor.Base.primary.color))
+                    .foregroundColor(AssetColor.Base.primary.color)
                     .font(.headline)
                 Spacer()
             }
@@ -21,12 +21,12 @@ public struct QuestionnaireView: View {
                 action: tapAnswerAction,
                 label: {
                     Text(L10n.HomeScreen.Questionnaire.answer)
-                        .foregroundColor(Color(AssetColor.primary.color))
+                        .foregroundColor(AssetColor.primary.color)
                         .padding(.vertical, 8)
                         .padding(.horizontal, 32)
                         .overlay(
                             Rectangle()
-                                .stroke(Color(AssetColor.primary.color))
+                                .stroke(AssetColor.primary.color)
                         )
                 }
             )

--- a/ios/templates/xcassets/swift5.stencil
+++ b/ios/templates/xcassets/swift5.stencil
@@ -16,15 +16,15 @@
 {% if resourceCount.aresourcegroup > 0 %}
   import ARKit
 {% endif %}
-  import UIKit
+  import SwiftUI
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
 
 // Deprecated typealiases
 {% if resourceCount.color > 0 %}
-@available(*, deprecated, renamed: "{{colorType}}.Color", message: "This typealias will be removed in SwiftGen 7.0")
-{{accessModifier}} typealias {{param.colorAliasName|default:"AssetColorTypeAlias"}} = {{colorType}}.Color
+@available(*, deprecated, renamed: "{{colorType}}.ColorClass", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.colorAliasName|default:"AssetColorTypeAlias"}} = {{colorType}}.ColorClass
 {% endif %}
 {% if resourceCount.image > 0 %}
 @available(*, deprecated, renamed: "{{imageType}}.Image", message: "This typealias will be removed in SwiftGen 7.0")
@@ -151,14 +151,14 @@
   {{accessModifier}} fileprivate(set) var name: String
 
   #if os(macOS)
-  {{accessModifier}} typealias Color = NSColor
+  {{accessModifier}} typealias ColorClass = NSColor
   #elseif os(iOS) || os(tvOS) || os(watchOS)
-  {{accessModifier}} typealias Color = UIColor
+  {{accessModifier}} typealias ColorClass = Color
   #endif
 
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  {{accessModifier}} private(set) lazy var color: Color = {
-    guard let color = Color(asset: self) else {
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} private(set) lazy var color: ColorClass = {
+    guard let color = ColorClass(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
     return color
@@ -169,12 +169,12 @@
   }
 }
 
-{{accessModifier}} extension {{colorType}}.Color {
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  convenience init?(asset: {{colorType}}) {
+{{accessModifier}} extension {{colorType}}.ColorClass {
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  init?(asset: {{colorType}}) {
     let bundle = {{param.bundle|default:"BundleToken.bundle"}}
     #if os(iOS) || os(tvOS)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    self.init(asset.name, bundle: bundle)
     #elseif os(macOS)
     self.init(named: NSColor.Name(asset.name), bundle: bundle)
     #elseif os(watchOS)


### PR DESCRIPTION
## Issue
- close #461

## Overview (Required)
- able to use asset color with type Color which can use in SwiftUI directly.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
