### PR TITLE
[iOS] Support UIColor for ColorAsset

### DIFF
--- a/ios/Sources/AppFeature/AppScreen.swift
+++ b/ios/Sources/AppFeature/AppScreen.swift
@@ -64,9 +64,9 @@ public struct AppScreen: View {
 
     public init(store: Store<AppState, AppAction>) {
         self.store = store
-        UITabBar.appearance().barTintColor = AssetColor.Background.contents.color
-        UITabBar.appearance().unselectedItemTintColor = AssetColor.Base.disable.color
-        UINavigationBar.appearance().barTintColor = AssetColor.Background.primary.color
+        UITabBar.appearance().barTintColor = AssetColor.Background.contents()
+        UITabBar.appearance().unselectedItemTintColor = AssetColor.Base.disable()
+        UINavigationBar.appearance().barTintColor = AssetColor.Background.primary()
     }
 
     public var body: some View {
@@ -83,8 +83,8 @@ public struct AppScreen: View {
                 }
             }
         )
-        .accentColor(Color(AssetColor.primary.color.cgColor))
-        .background(Color(AssetColor.Background.primary.color))
+        .accentColor(AssetColor.primary())
+        .background(AssetColor.Background.primary())
     }
 }
 

--- a/ios/Sources/Component/Card/LargeCard.swift
+++ b/ios/Sources/Component/Card/LargeCard.swift
@@ -36,7 +36,7 @@ public struct LargeCard: View {
 
                 Text(title)
                     .font(.headline)
-                    .foregroundColor(AssetColor.Base.primary.color)
+                    .foregroundColor(AssetColor.Base.primary())
                     .lineLimit(2)
 
                 HStack(spacing: 8) {
@@ -46,7 +46,7 @@ public struct LargeCard: View {
 
                     Text(date.formatted)
                         .font(.caption)
-                        .foregroundColor(AssetColor.Base.tertiary.color)
+                        .foregroundColor(AssetColor.Base.tertiary())
 
                     Spacer()
 
@@ -54,12 +54,12 @@ public struct LargeCard: View {
                         let uiImage = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
                         Image(uiImage: uiImage)
                             .renderingMode(.template)
-                            .foregroundColor(AssetColor.primary.color)
+                            .foregroundColor(AssetColor.primary())
                     })
                 }
             }
             .padding(16)
-            .background(AssetColor.Background.primary.color)
+            .background(AssetColor.Background.primary())
         })
     }
 }

--- a/ios/Sources/Component/Card/MediumCard.swift
+++ b/ios/Sources/Component/Card/MediumCard.swift
@@ -37,12 +37,12 @@ public struct MediumCard: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(title)
                             .font(.subheadline)
-                            .foregroundColor(AssetColor.Base.primary.color)
+                            .foregroundColor(AssetColor.Base.primary())
                             .lineLimit(2)
 
                         Text(date.formatted)
                             .font(.caption)
-                            .foregroundColor(AssetColor.Base.tertiary.color)
+                            .foregroundColor(AssetColor.Base.tertiary())
                     }
 
                     HStack(spacing: 8) {
@@ -56,13 +56,13 @@ public struct MediumCard: View {
                             let uiImage = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
                             Image(uiImage: uiImage)
                                 .renderingMode(.template)
-                                .foregroundColor(AssetColor.primary.color)
+                                .foregroundColor(AssetColor.primary())
                         })
                     }
                 }
             }
             .padding(16)
-            .background(AssetColor.Background.primary.color)
+            .background(AssetColor.Background.primary())
         })
     }
 }

--- a/ios/Sources/Component/Card/SmallCard.swift
+++ b/ios/Sources/Component/Card/SmallCard.swift
@@ -38,12 +38,12 @@ public struct SmallCard: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(title)
                             .font(.subheadline)
-                            .foregroundColor(AssetColor.Base.primary.color)
+                            .foregroundColor(AssetColor.Base.primary())
                             .lineLimit(2)
 
                         Text(date.formatted)
                             .font(.caption)
-                            .foregroundColor(AssetColor.Base.tertiary.color)
+                            .foregroundColor(AssetColor.Base.tertiary())
                     }
 
                     HStack(spacing: 8) {
@@ -57,13 +57,13 @@ public struct SmallCard: View {
                             let uiImage = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
                             Image(uiImage: uiImage)
                                 .renderingMode(.template)
-                                .foregroundColor(AssetColor.primary.color)
+                                .foregroundColor(AssetColor.primary())
                         })
                     }
                 }
             }
             .padding(8)
-            .background(AssetColor.Background.primary.color)
+            .background(AssetColor.Background.primary())
         })
     }
 }

--- a/ios/Sources/Component/ImageView/ImageView.swift
+++ b/ios/Sources/Component/ImageView/ImageView.swift
@@ -19,11 +19,11 @@ public struct ImageView: View {
     public var body: some View {
         // TODO: add placeholder image
         Image("")
-            .background(AssetColor.Base.secondary.color)
+            .background(AssetColor.Base.secondary())
             .frame(width: width, height: height, alignment: .center)
             .overlay(
                 RoundedRectangle(cornerRadius: 2)
-                    .stroke(AssetColor.Separate.image.color, lineWidth: 1)
+                    .stroke(AssetColor.Separate.image(), lineWidth: 1)
             )
     }
 }

--- a/ios/Sources/Component/MessageBar/MessageBar.swift
+++ b/ios/Sources/Component/MessageBar/MessageBar.swift
@@ -13,10 +13,10 @@ public struct MessageBar: View {
     public var body: some View {
         Text(title)
             .font(.subheadline)
-            .foregroundColor(AssetColor.Base.white.color)
+            .foregroundColor(AssetColor.Base.white())
             .padding(.vertical, 8)
             .padding(.horizontal, 12)
-            .background(AssetColor.primaryDark.color)
+            .background(AssetColor.primaryDark())
             .cornerRadius(4)
     }
 }

--- a/ios/Sources/Component/Tag/Tag.swift
+++ b/ios/Sources/Component/Tag/Tag.swift
@@ -16,7 +16,7 @@ public struct Tag: View {
     public var body: some View {
         Text(type.title)
             .font(.caption)
-            .foregroundColor(AssetColor.Base.white.color)
+            .foregroundColor(AssetColor.Base.white())
             .padding(.vertical, 4)
             .padding(.horizontal, 12)
             .background(type.backgroundColor)
@@ -63,11 +63,11 @@ private extension TagType {
     var backgroundColor: Color {
         switch self {
         case .droidKaigiFm:
-            return AssetColor.secondary.color
+            return AssetColor.secondary()
         case .medium:
-            return AssetColor.Tag.medium.color
+            return AssetColor.Tag.medium()
         case .youtube:
-            return AssetColor.Tag.video.color
+            return AssetColor.Tag.video()
         }
     }
 }

--- a/ios/Sources/HomeFeature/HomeScreen.swift
+++ b/ios/Sources/HomeFeature/HomeScreen.swift
@@ -14,42 +14,42 @@ public struct HomeScreen: View {
             NavigationView {
                 ScrollView {
                     ZStack(alignment: .top) {
-                        Color(AssetColor.primary.color)
+                        AssetColor.primary()
                             .frame(width: nil, height: 200)
                         WithViewStore(store) { viewStore in
                             VStack(alignment: .trailing, spacing: 0) {
                                 Text("DroidKaigi 2021 (7/31) D-7")
-                                    .foregroundColor(Color(AssetColor.Base.white.color))
+                                    .foregroundColor(AssetColor.Base.white())
                                     .padding(.vertical, 12)
                                     .padding(.horizontal, 8)
-                                    .background(Color(AssetColor.primaryDark.color))
+                                    .background(AssetColor.primaryDark())
                                     .padding(.vertical)
                                 // TODO: Replace with card(large)
                                 Rectangle()
                                     .frame(width: nil, height: 300)
                                 Divider()
-                                    .foregroundColor(Color(AssetColor.Separate.contents.color))
+                                    .foregroundColor(AssetColor.Separate.contents())
                                 QuestionnaireView(tapAnswerAction: {
                                     viewStore.send(.answerQuestionnaire)
                                 })
                                 Divider()
-                                    .foregroundColor(Color(AssetColor.Separate.contents.color))
+                                    .foregroundColor(AssetColor.Separate.contents())
                                 ForEach(viewStore.contents, id: \.self) { content in
                                     // TODO: Replace with List Item
                                     Text(content)
-                                        .foregroundColor(Color(AssetColor.Base.primary.color))
+                                        .foregroundColor(AssetColor.Base.primary())
                                 }
                             }
                             .padding(.horizontal)
                         }
                     }
                 }
-                .background(Color(AssetColor.Background.primary.color))
+                .background(AssetColor.Background.primary())
                 .navigationBarTitle("", displayMode: .inline)
                 .navigationBarItems(
                     trailing: Image(uiImage: AssetImage.iconSetting.image)
                         .renderingMode(.template)
-                        .foregroundColor(Color(AssetColor.Base.primary.color))
+                        .foregroundColor(AssetColor.Base.primary())
                 )
             }
             Image(uiImage: AssetImage.logoTitle.image)

--- a/ios/Sources/HomeFeature/QuestionnaireView.swift
+++ b/ios/Sources/HomeFeature/QuestionnaireView.swift
@@ -13,7 +13,7 @@ public struct QuestionnaireView: View {
             HStack {
                 Image(uiImage: AssetImage.logo.image)
                 Text(L10n.HomeScreen.Questionnaire.title)
-                    .foregroundColor(AssetColor.Base.primary.color)
+                    .foregroundColor(AssetColor.Base.primary())
                     .font(.headline)
                 Spacer()
             }
@@ -21,12 +21,12 @@ public struct QuestionnaireView: View {
                 action: tapAnswerAction,
                 label: {
                     Text(L10n.HomeScreen.Questionnaire.answer)
-                        .foregroundColor(AssetColor.primary.color)
+                        .foregroundColor(AssetColor.primary())
                         .padding(.vertical, 8)
                         .padding(.horizontal, 32)
                         .overlay(
                             Rectangle()
-                                .stroke(AssetColor.primary.color)
+                                .stroke(AssetColor.primary())
                         )
                 }
             )

--- a/ios/templates/xcassets/swift5.stencil
+++ b/ios/templates/xcassets/swift5.stencil
@@ -171,6 +171,12 @@ import SwiftUI
   fileprivate init(name: String) {
     self.name = name
   }
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} func callAsFunction() -> Color { color }
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  {{accessModifier}} func callAsFunction() -> ColorClass { colorObject }
 }
 
 {{accessModifier}} extension {{colorType}}.ColorClass {

--- a/ios/templates/xcassets/swift5.stencil
+++ b/ios/templates/xcassets/swift5.stencil
@@ -10,13 +10,14 @@
 {% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
 {% set forceNamespaces %}{{param.forceProvidesNamespaces|default:"false"}}{% endset %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+import SwiftUI
 #if os(macOS)
   import AppKit
 #elseif os(iOS)
 {% if resourceCount.aresourcegroup > 0 %}
   import ARKit
 {% endif %}
-  import SwiftUI
+  import UIKit
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
@@ -153,11 +154,14 @@
   #if os(macOS)
   {{accessModifier}} typealias ColorClass = NSColor
   #elseif os(iOS) || os(tvOS) || os(watchOS)
-  {{accessModifier}} typealias ColorClass = Color
+  {{accessModifier}} typealias ColorClass = UIColor
   #endif
 
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  {{accessModifier}} private(set) lazy var color: ColorClass = {
+  {{accessModifier}} private(set) lazy var color = Color(name, bundle: {{param.bundle|default:"BundleToken.bundle"}})
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  {{accessModifier}} private(set) lazy var colorObject: ColorClass = {
     guard let color = ColorClass(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
@@ -170,11 +174,11 @@
 }
 
 {{accessModifier}} extension {{colorType}}.ColorClass {
-  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  init?(asset: {{colorType}}) {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  convenience init?(asset: {{colorType}}) {
     let bundle = {{param.bundle|default:"BundleToken.bundle"}}
     #if os(iOS) || os(tvOS)
-    self.init(asset.name, bundle: bundle)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
     self.init(named: NSColor.Name(asset.name), bundle: bundle)
     #elseif os(watchOS)


### PR DESCRIPTION
## Issue

#466 has accidentally broken the support of UIColor.

## Overview (Required)

- Support `UIColor` for `ColorAsset`
- Use `callAsFunction` to overload colors
- Update codes which using `AssetColor`

## Proposal

If this approach is fine, I would like to apply it to `ImageAsset`.

## Another Plan

#472 