### PR TITLE
[iOS] Support UIColor for ColorAsset (Plan B)

### DIFF
--- a/ios/Sources/AppFeature/AppScreen.swift
+++ b/ios/Sources/AppFeature/AppScreen.swift
@@ -25,7 +25,7 @@ enum AppTab: CaseIterable {
         }
     }
 
-    var image: UIImage {
+    var image: Image {
         switch self {
         case .home:
             return AssetImage.iconHome.image
@@ -76,7 +76,7 @@ public struct AppScreen: View {
                 ForEach(Array(AppTab.allCases.enumerated()), id: \.offset) { (offset, tab) in
                     tab.view(store)
                         .tabItem {
-                            Image(uiImage: tab.image)
+                            tab.image
                             Text(tab.title)
                         }
                         .tag(offset)

--- a/ios/Sources/AppFeature/AppScreen.swift
+++ b/ios/Sources/AppFeature/AppScreen.swift
@@ -64,9 +64,9 @@ public struct AppScreen: View {
 
     public init(store: Store<AppState, AppAction>) {
         self.store = store
-        UITabBar.appearance().barTintColor = UIColor(AssetColor.Background.contents.color)
-        UITabBar.appearance().unselectedItemTintColor = UIColor(AssetColor.Base.disable.color)
-        UINavigationBar.appearance().barTintColor = UIColor(AssetColor.Background.primary.color)
+        UITabBar.appearance().barTintColor = AssetColor.Background.contents.uiColor
+        UITabBar.appearance().unselectedItemTintColor = AssetColor.Base.disable.uiColor
+        UINavigationBar.appearance().barTintColor = AssetColor.Background.primary.uiColor
     }
 
     public var body: some View {

--- a/ios/Sources/Component/Card/LargeCard.swift
+++ b/ios/Sources/Component/Card/LargeCard.swift
@@ -51,8 +51,8 @@ public struct LargeCard: View {
                     Spacer()
 
                     Button(action: tapFavoriteAction, label: {
-                        let uiImage = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
-                        Image(uiImage: uiImage)
+                        let image = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
+                        image
                             .renderingMode(.template)
                             .foregroundColor(AssetColor.primary.color)
                     })

--- a/ios/Sources/Component/Card/MediumCard.swift
+++ b/ios/Sources/Component/Card/MediumCard.swift
@@ -53,8 +53,8 @@ public struct MediumCard: View {
                         Spacer()
 
                         Button(action: tapFavoriteAction, label: {
-                            let uiImage = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
-                            Image(uiImage: uiImage)
+                            let image = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
+                            image
                                 .renderingMode(.template)
                                 .foregroundColor(AssetColor.primary.color)
                         })

--- a/ios/Sources/Component/Card/SmallCard.swift
+++ b/ios/Sources/Component/Card/SmallCard.swift
@@ -54,8 +54,8 @@ public struct SmallCard: View {
                         Spacer()
 
                         Button(action: tapFavoriteAction, label: {
-                            let uiImage = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
-                            Image(uiImage: uiImage)
+                            let image = isFavorited ? AssetImage.iconFavorite.image : AssetImage.iconFavoriteOff.image
+                            image
                                 .renderingMode(.template)
                                 .foregroundColor(AssetColor.primary.color)
                         })

--- a/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
+++ b/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
@@ -2,7 +2,7 @@ import Styleguide
 import SwiftUI
 
 public extension View {
-    func navigationBarColor(backgroundColor: Color, titleColor: Color) -> some View {
+    func navigationBarColor(backgroundColor: UIColor, titleColor: UIColor) -> some View {
         modifier(NavigationBarConfigurator(backgroundColor: backgroundColor, titleColor: titleColor))
     }
 }
@@ -11,15 +11,15 @@ private struct NavigationBarConfigurator: ViewModifier {
     private let previousBackgroundColor: UIColor?
     private let previousTitleColor: UIColor?
 
-    init(backgroundColor: Color, titleColor: Color) {
+    init(backgroundColor: UIColor, titleColor: UIColor) {
         previousTitleColor = UINavigationBar.appearance().standardAppearance.titleTextAttributes[.foregroundColor] as? UIColor
         previousBackgroundColor = UINavigationBar.appearance().standardAppearance.backgroundColor
 
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
 
-        appearance.titleTextAttributes = [.foregroundColor: UIColor(titleColor)]
-        appearance.backgroundColor = UIColor(backgroundColor)
+        appearance.titleTextAttributes = [.foregroundColor: titleColor]
+        appearance.backgroundColor = backgroundColor
         UINavigationBar.appearance().standardAppearance = appearance
     }
 

--- a/ios/Sources/HomeFeature/HomeScreen.swift
+++ b/ios/Sources/HomeFeature/HomeScreen.swift
@@ -47,12 +47,12 @@ public struct HomeScreen: View {
                 .background(AssetColor.Background.primary.color)
                 .navigationBarTitle("", displayMode: .inline)
                 .navigationBarItems(
-                    trailing: Image(uiImage: AssetImage.iconSetting.image)
+                    trailing: AssetImage.iconSetting.image
                         .renderingMode(.template)
                         .foregroundColor(AssetColor.Base.primary.color)
                 )
             }
-            Image(uiImage: AssetImage.logoTitle.image)
+            AssetImage.logoTitle.image
                 .frame(width: nil, height: 44, alignment: .center)
         }
     }

--- a/ios/Sources/HomeFeature/QuestionnaireView.swift
+++ b/ios/Sources/HomeFeature/QuestionnaireView.swift
@@ -11,7 +11,7 @@ public struct QuestionnaireView: View {
     public var body: some View {
         VStack(alignment: .trailing, spacing: 12) {
             HStack {
-                Image(uiImage: AssetImage.logo.image)
+                AssetImage.logo.image
                 Text(L10n.HomeScreen.Questionnaire.title)
                     .foregroundColor(AssetColor.Base.primary.color)
                     .font(.headline)

--- a/ios/Sources/SettingFeature/SettingScreen.swift
+++ b/ios/Sources/SettingFeature/SettingScreen.swift
@@ -66,7 +66,7 @@ public struct SettingScreen: View {
                 trailing: Button(action: {
                     presentationMode.wrappedValue.dismiss()
                 }, label: {
-                    Image(uiImage: AssetImage.iconClose.image)
+                    AssetImage.iconClose.image
                         .renderingMode(.template)
                         .foregroundColor(AssetColor.Base.primary.color)
                 })

--- a/ios/Sources/SettingFeature/SettingScreen.swift
+++ b/ios/Sources/SettingFeature/SettingScreen.swift
@@ -43,7 +43,7 @@ public struct SettingScreen: View {
         let languageModel = SettingModel.language(isOn: isLanguageOn)
         _items = State(initialValue: [darkModeModel, languageModel])
 
-        UITableView.appearance().backgroundColor = UIColor(AssetColor.Background.primary.color)
+        UITableView.appearance().backgroundColor = AssetColor.Background.primary.uiColor
     }
 
     public var body: some View {
@@ -72,8 +72,8 @@ public struct SettingScreen: View {
                 })
             )
             .navigationBarColor(
-                backgroundColor: AssetColor.Background.primary.color,
-                titleColor: AssetColor.Base.primary.color
+                backgroundColor: AssetColor.Background.primary.uiColor,
+                titleColor: AssetColor.Base.primary.uiColor
             )
         }
     }

--- a/ios/templates/xcassets/swift5.stencil
+++ b/ios/templates/xcassets/swift5.stencil
@@ -10,22 +10,20 @@
 {% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
 {% set forceNamespaces %}{{param.forceProvidesNamespaces|default:"false"}}{% endset %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set bundle %}{{param.bundle|default:"BundleToken.bundle"}}{% endset %}
+import SwiftUI
 #if os(macOS)
   import AppKit
 #elseif os(iOS)
 {% if resourceCount.aresourcegroup > 0 %}
   import ARKit
 {% endif %}
-  import SwiftUI
+  import UIKit
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
 
 // Deprecated typealiases
-{% if resourceCount.color > 0 %}
-@available(*, deprecated, renamed: "{{colorType}}.ColorClass", message: "This typealias will be removed in SwiftGen 7.0")
-{{accessModifier}} typealias {{param.colorAliasName|default:"AssetColorTypeAlias"}} = {{colorType}}.ColorClass
-{% endif %}
 {% if resourceCount.image > 0 %}
 @available(*, deprecated, renamed: "{{imageType}}.Image", message: "This typealias will be removed in SwiftGen 7.0")
 {{accessModifier}} typealias {{param.imageAliasName|default:"AssetImageTypeAlias"}} = {{imageType}}.Image
@@ -131,16 +129,14 @@
 @available(iOS 11.3, *)
 {{accessModifier}} extension ARReferenceImage {
   static func referenceImages(in asset: {{arResourceGroupType}}) -> Set<ARReferenceImage> {
-    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
-    return referenceImages(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+    return referenceImages(inGroupNamed: asset.name, bundle: {{bundle}}) ?? Set()
   }
 }
 
 @available(iOS 12.0, *)
 {{accessModifier}} extension ARReferenceObject {
   static func referenceObjects(in asset: {{arResourceGroupType}}) -> Set<ARReferenceObject> {
-    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
-    return referenceObjects(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+    return referenceObjects(inGroupNamed: asset.name, bundle: {{bundle}}) ?? Set()
   }
 }
 #endif
@@ -150,36 +146,26 @@
 {{accessModifier}} final class {{colorType}} {
   {{accessModifier}} fileprivate(set) var name: String
 
-  #if os(macOS)
-  {{accessModifier}} typealias ColorClass = NSColor
-  #elseif os(iOS) || os(tvOS) || os(watchOS)
-  {{accessModifier}} typealias ColorClass = Color
-  #endif
-
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  {{accessModifier}} private(set) lazy var color: ColorClass = {
-    guard let color = ColorClass(asset: self) else {
-      fatalError("Unable to load color asset named \(name).")
-    }
-    return color
+  {{accessModifier}} private(set) lazy var color = Color(name, bundle: {{bundle}})
+
+  #if os(macOS)
+  @available(macOS 10.13, *)
+  {{accessModifier}} private(set) lazy var nsColor = NSColor(named: name, in: {{bundle}})
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+  {{accessModifier}} private(set) lazy var uiColor: UIColor = {
+    #if os(watchOS)
+    let uiColor = UIColor(named: name)
+    #else
+    let uiColor = UIColor(named: name, in: {{bundle}}, compatibleWith: nil)
+    #endif
+    return uiColor ?? { fatalError("Unable to load data asset named \(name).") }()
   }()
+  #endif
 
   fileprivate init(name: String) {
     self.name = name
-  }
-}
-
-{{accessModifier}} extension {{colorType}}.ColorClass {
-  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  init?(asset: {{colorType}}) {
-    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
-    #if os(iOS) || os(tvOS)
-    self.init(asset.name, bundle: bundle)
-    #elseif os(macOS)
-    self.init(named: NSColor.Name(asset.name), bundle: bundle)
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
   }
 }
 {% endif %}
@@ -203,11 +189,10 @@
 @available(iOS 9.0, macOS 10.11, *)
 {{accessModifier}} extension NSDataAsset {
   convenience init?(asset: {{dataType}}) {
-    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
     #if os(iOS) || os(tvOS)
-    self.init(name: asset.name, bundle: bundle)
+    self.init(name: asset.name, bundle: {{bundle}})
     #elseif os(macOS)
-    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: {{bundle}})
     #endif
   }
 }

--- a/ios/templates/xcassets/swift5.stencil
+++ b/ios/templates/xcassets/swift5.stencil
@@ -23,12 +23,6 @@ import SwiftUI
   import UIKit
 #endif
 
-// Deprecated typealiases
-{% if resourceCount.image > 0 %}
-@available(*, deprecated, renamed: "{{imageType}}.Image", message: "This typealias will be removed in SwiftGen 7.0")
-{{accessModifier}} typealias {{param.imageAliasName|default:"AssetImageTypeAlias"}} = {{imageType}}.Image
-{% endif %}
-
 // swiftlint:disable superfluous_disable_command file_length implicit_return
 
 // MARK: - Asset Catalogs
@@ -203,42 +197,23 @@ import SwiftUI
 {{accessModifier}} struct {{imageType}} {
   {{accessModifier}} fileprivate(set) var name: String
 
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} var image: Image { Image(name, bundle: {{bundle}}) }
+
   #if os(macOS)
-  {{accessModifier}} typealias Image = NSImage
+  @available(macOS 10.13, *)
+  {{accessModifier}} private(set) lazy var nsImage = ({{bundle}} == .main) ? NSImage(named: name) : {{bundle}}.image(forResource: name)
   #elseif os(iOS) || os(tvOS) || os(watchOS)
-  {{accessModifier}} typealias Image = UIImage
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+  {{accessModifier}} var uiImage: UIImage {
+    #if os(watchOS)
+    let uiImage = UIImage(named: name)
+    #else
+    let uiImage = UIImage(named: name, in: {{bundle}}, compatibleWith: nil)
+    #endif
+    return uiImage ?? { fatalError("Unable to load image asset named \(name).") }()
+  }
   #endif
-
-  {{accessModifier}} var image: Image {
-    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
-    #if os(iOS) || os(tvOS)
-    let image = Image(named: name, in: bundle, compatibleWith: nil)
-    #elseif os(macOS)
-    let name = NSImage.Name(self.name)
-    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
-    #elseif os(watchOS)
-    let image = Image(named: name)
-    #endif
-    guard let result = image else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
-  }
-}
-
-{{accessModifier}} extension {{imageType}}.Image {
-  @available(macOS, deprecated,
-    message: "This initializer is unsafe on macOS, please use the {{imageType}}.image property")
-  convenience init?(asset: {{imageType}}) {
-    #if os(iOS) || os(tvOS)
-    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(macOS)
-    self.init(named: NSImage.Name(asset.name))
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
 }
 {% endif %}
 {% if not param.bundle %}


### PR DESCRIPTION
## Issue

#466 has accidentally broken the support of UIColor.

## Overview (Required)

- Support `UIColor` for `ColorAsset`
- Separate `Color` and `NSColor`
- Make similar change as `ColorAsset` for `ImageAsset`
- Update codes which using `AssetColor` or `AssetImage`

## Another Plan

Closes: #467