### PR TITLE
[iOS] Fix previous color properties

### DIFF
--- a/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
+++ b/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
@@ -7,36 +7,33 @@ public extension View {
     }
 }
 
-fileprivate struct NavigationBarConfigurator: ViewModifier {
-    
+private struct NavigationBarConfigurator: ViewModifier {
     private let previousBackgroundColor: UIColor?
     private let previousTitleColor: UIColor?
-    
+
     init(backgroundColor: Color, titleColor: Color) {
-        
         previousTitleColor = UINavigationBar.appearance().standardAppearance.titleTextAttributes[.foregroundColor] as? UIColor
         previousBackgroundColor = UINavigationBar.appearance().standardAppearance.backgroundColor
-        
+
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
-        
+
         appearance.titleTextAttributes = [.foregroundColor: UIColor(titleColor)]
         appearance.backgroundColor = UIColor(backgroundColor)
         UINavigationBar.appearance().standardAppearance = appearance
     }
-    
+
     func body(content: Content) -> some View {
         content
             .onDisappear(perform: {
-                
+
                 if let previousBackgroundColor = previousBackgroundColor {
                     UINavigationBar.appearance().backgroundColor = previousBackgroundColor
                 }
-                
+
                 if let previousTitleColor = previousTitleColor {
                     UINavigationBar.appearance().titleTextAttributes?[.foregroundColor] = previousTitleColor
                 }
             })
     }
-    
 }

--- a/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
+++ b/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
@@ -9,23 +9,13 @@ public extension View {
 
 fileprivate struct NavigationBarConfigurator: ViewModifier {
     
-    private let previousBackgroundColor: Color?
-    private let previousTitleColor: Color?
+    private let previousBackgroundColor: UIColor?
+    private let previousTitleColor: UIColor?
     
     init(backgroundColor: Color, titleColor: Color) {
         
-        if let previousTitleColor = UINavigationBar.appearance().standardAppearance.titleTextAttributes[.foregroundColor] as? UIColor {
-            self.previousTitleColor = Color(previousTitleColor)
-        } else {
-            self.previousTitleColor = nil
-        }
-        
-        if let previousBackgroundColor = UINavigationBar.appearance().standardAppearance.backgroundColor {
-            self.previousBackgroundColor = Color(previousBackgroundColor)
-        } else {
-            self.previousBackgroundColor = nil
-        }
-        
+        previousTitleColor = UINavigationBar.appearance().standardAppearance.titleTextAttributes[.foregroundColor] as? UIColor
+        previousBackgroundColor = UINavigationBar.appearance().standardAppearance.backgroundColor
         
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
@@ -40,7 +30,7 @@ fileprivate struct NavigationBarConfigurator: ViewModifier {
             .onDisappear(perform: {
                 
                 if let previousBackgroundColor = previousBackgroundColor {
-                    UINavigationBar.appearance().backgroundColor = UIColor(previousBackgroundColor)
+                    UINavigationBar.appearance().backgroundColor = previousBackgroundColor
                 }
                 
                 if let previousTitleColor = previousTitleColor {

--- a/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
+++ b/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
@@ -22,10 +22,14 @@ fileprivate struct NavigationBarConfigurator: ViewModifier {
         
         if let previousTitleColor = UINavigationBar.appearance().standardAppearance.titleTextAttributes[.foregroundColor] as? UIColor {
             self.previousTitleColor = Color(previousTitleColor)
+        } else {
+            self.previousTitleColor = nil
         }
         
         if let previousBackgroundColor = UINavigationBar.appearance().standardAppearance.backgroundColor {
             self.previousBackgroundColor = Color(previousBackgroundColor)
+        } else {
+            self.previousBackgroundColor = nil
         }
         
         

--- a/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
+++ b/ios/Sources/Component/NavigationBar/NavigationBarConfigurator.swift
@@ -9,16 +9,10 @@ public extension View {
 
 fileprivate struct NavigationBarConfigurator: ViewModifier {
     
-    private let newBackgroundColor: Color
-    private let newTitleColor: Color
-    
     private let previousBackgroundColor: Color?
     private let previousTitleColor: Color?
     
     init(backgroundColor: Color, titleColor: Color) {
-        
-        self.newBackgroundColor = backgroundColor
-        self.newTitleColor = titleColor
         
         if let previousTitleColor = UINavigationBar.appearance().standardAppearance.titleTextAttributes[.foregroundColor] as? UIColor {
             self.previousTitleColor = Color(previousTitleColor)


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- It seems like the latest commit cannot build, so this PR contains the following changes to fix that:
  - Initialize all properties in initializer to fix a compile error
  - Change the type of previous color properties to avoid redundant conversions

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
