### PR TITLE
[iOS] Change default CPU architecture

### DIFF
--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -24,8 +24,8 @@ kotlin {
     // The multiplatform libraries do not support hierarchical structures, which breaks the IDE's completion.
     // https://kotlinlang.org/docs/mpp-share-on-platforms.html#share-code-on-similar-platforms
     def iosTargets = [
-            iosArm64("ios"),
-            iosX64()
+            iosArm64(),
+            iosX64("ios")
     ]
     iosTargets.forEach {
         it.binaries.forEach {
@@ -94,7 +94,7 @@ kotlin {
             implementation Dep.Ktor.ios
             implementation Dep.Koin.core
         }
-        iosX64Main.dependsOn(iosMain)
+        iosArm64Main.dependsOn(iosMain)
     }
 }
 

--- a/data/db/build.gradle
+++ b/data/db/build.gradle
@@ -25,8 +25,8 @@ kotlin {
     // The multiplatform libraries do not support hierarchical structures, which breaks the IDE's completion.
     // https://kotlinlang.org/docs/mpp-share-on-platforms.html#share-code-on-similar-platforms
     def iosTargets = [
-            iosArm64("ios"),
-            iosX64()
+            iosArm64(),
+            iosX64("ios")
     ]
     iosTargets.forEach {
         it.binaries.forEach {
@@ -92,7 +92,7 @@ kotlin {
             implementation Dep.Koin.core
             implementation "com.squareup.sqldelight:native-driver:1.4.4"
         }
-        iosX64Main.dependsOn(iosMain)
+        iosArm64Main.dependsOn(iosMain)
     }
 }
 

--- a/data/repository/build.gradle
+++ b/data/repository/build.gradle
@@ -24,8 +24,8 @@ kotlin {
     // The multiplatform libraries do not support hierarchical structures, which breaks the IDE's completion.
     // https://kotlinlang.org/docs/mpp-share-on-platforms.html#share-code-on-similar-platforms
     def iosTargets = [
-            iosArm64("ios"),
-            iosX64()
+            iosArm64(),
+            iosX64("ios")
     ]
     iosTargets.forEach {
         it.binaries.forEach {
@@ -77,7 +77,7 @@ kotlin {
         iosMain.dependencies {
             implementation Dep.Koin.core
         }
-        iosX64Main.dependsOn(iosMain)
+        iosArm64Main.dependsOn(iosMain)
     }
 }
 

--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
     android()
 
     val iosTargets = listOf(
-        iosArm64("ios"),
-        iosX64()
+        iosArm64(),
+        iosX64("ios")
     )
     iosTargets.forEach {
         it.binaries {
@@ -55,7 +55,7 @@ kotlin {
                 implementation(Dep.Koin.core)
             }
         }
-        val iosX64Main by getting {
+        val iosArm64Main by getting {
             dependsOn(iosMain)
         }
         val iosTest by getting


### PR DESCRIPTION
## Issue

Fix #469 

## Overview (Required)

It seems like `iosArm64` doesn't have a test task and `iosX64Test` can't depend on `iosTest`, which builds `iosArm64`.
So change `ios` to `iosX64` should work.

I have chosen`iosArm64` as the default CPU architecture since it's more suitable to call `ios`, but it looks like a bad idea.