### PR TITLE
Use NukeUI(Nuke) to load & display image

### DIFF
--- a/ios/DroidKaigi2021.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DroidKaigi2021.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,12 +20,39 @@
         }
       },
       {
+        "package": "Gifu",
+        "repositoryURL": "https://github.com/kaishin/Gifu",
+        "state": {
+          "branch": null,
+          "revision": "0ffe24744cc3d82ab9edece53670d0352c6d5507",
+          "version": "3.3.0"
+        }
+      },
+      {
         "package": "Kanna",
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
           "revision": "c657fb9f5827ef138068215c76ad0bb62bbc92da",
           "version": "5.2.4"
+        }
+      },
+      {
+        "package": "Nuke",
+        "repositoryURL": "https://github.com/kean/Nuke.git",
+        "state": {
+          "branch": null,
+          "revision": "35cd3fa3bcea8becf826d9610c1f5bba8f57b728",
+          "version": "10.2.0"
+        }
+      },
+      {
+        "package": "NukeUI",
+        "repositoryURL": "https://github.com/kean/NukeUI.git",
+        "state": {
+          "branch": null,
+          "revision": "2e3fd56a135dad891747c83607e98c896162f974",
+          "version": "0.4.0"
         }
       },
       {

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -54,6 +54,7 @@ var package = Package(
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", .exact("0.18.0")),
         .package(name: "Introspect", url: "https://github.com/siteline/SwiftUI-Introspect.git", .upToNextMajor(from: "0.1.3")),
+        .package(url: "https://github.com/kean/NukeUI.git", .exact("0.4.0")),
     ],
     targets: [
         .target(
@@ -80,6 +81,7 @@ var package = Package(
             dependencies: [
                 .target(name: "Styleguide"),
                 .product(name: "Introspect", package: "Introspect"),
+                .product(name: "NukeUI", package: "NukeUI"),
             ]
         ),
         .target(

--- a/ios/Sources/Component/ImageView/ImageView.swift
+++ b/ios/Sources/Component/ImageView/ImageView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Styleguide
+import NukeUI
 
 public enum PlaceHolder {
     case noImage
@@ -48,30 +49,31 @@ public struct ImageView: View {
     }
 
     public var body: some View {
-        // TODO: load image from url
-        if let imageURL = imageURL {
-            Image("")
-                .resizable()
-                .background(AssetColor.Background.secondary.color.colorScheme(.light))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2)
-                        .stroke(AssetColor.Separate.image.color, lineWidth: 1)
-                )
-        } else {
-            placeholder.image
-                .resizable()
-                .frame(
-                    width: placeholderSize.frame.width,
-                    height: placeholderSize.frame.height,
-                    alignment: .center
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(AssetColor.Background.secondary.color.colorScheme(.light))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2)
-                        .stroke(AssetColor.Separate.image.color, lineWidth: 1)
-                )
-        }
+        LazyImage(source: imageURL)
+            .placeholder {
+                placeholderView
+            }
+            .failure {
+                placeholderView
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 2)
+                    .stroke(AssetColor.Separate.image.color, lineWidth: 1)
+            )
+    }
+}
+
+extension ImageView {
+    private var placeholderView: some View {
+        placeholder.image
+            .resizable()
+            .frame(
+                width: placeholderSize.frame.width,
+                height: placeholderSize.frame.height,
+                alignment: .center
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AssetColor.Background.secondary.color.colorScheme(.light))
     }
 }
 
@@ -109,7 +111,6 @@ struct ImageView_Previews: PreviewProvider {
             )
             .frame(width: 225, height: 114)
             .previewLayout(.sizeThatFits)
-
 
             ImageView(
                 imageURL: nil,

--- a/ios/Sources/Component/ImageView/ImageView.swift
+++ b/ios/Sources/Component/ImageView/ImageView.swift
@@ -1,6 +1,6 @@
+import NukeUI
 import SwiftUI
 import Styleguide
-import NukeUI
 
 public enum PlaceHolder {
     case noImage

--- a/ios/Sources/Component/ImageView/ImageView.swift
+++ b/ios/Sources/Component/ImageView/ImageView.swift
@@ -69,8 +69,7 @@ extension ImageView {
             .resizable()
             .frame(
                 width: placeholderSize.frame.width,
-                height: placeholderSize.frame.height,
-                alignment: .center
+                height: placeholderSize.frame.height
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(AssetColor.Background.secondary.color.colorScheme(.light))


### PR DESCRIPTION
## Issue
- close none

## Overview (Required)
- use NukeUI(Nuke) to load  & display image
- make sure placeholder works same as https://github.com/DroidKaigi/conference-app-2021/pull/488

## Links
- https://kean.blog/nuke/guides/swiftui

## Screenshot 
After Screen | After Components
:--: | :--:
<img src="https://user-images.githubusercontent.com/27538852/121530566-81d2fe80-ca38-11eb-98c1-834509e6ead4.png" width="300" /> | <img src="https://user-images.githubusercontent.com/27538852/121530581-85ff1c00-ca38-11eb-981d-cce1127e9684.png" width="300" />

