### PR TITLE
[iOS] Export kotlinx-datetime to the iOS Framework

### DIFF
--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
                 baseName = "DroidKaigiMPP"
                 export(project(":model"))
                 export(project(":data:repository"))
+                export(Dep.datetime)
                 linkerOpts.add("-lsqlite3")
             }
         }

--- a/ios/Sources/Model/Blog.swift
+++ b/ios/Sources/Model/Blog.swift
@@ -40,9 +40,7 @@ public struct Blog: Equatable, Identifiable {
             image: Image(from: model.image),
             link: model.link,
             media: Media.from(model.media),
-            publishedAt: Date(
-                timeIntervalSince1970: Double(model.publishedAt.toEpochMilliseconds())
-            ),
+            publishedAt: model.publishedAt.toNSDate(),
             summary: MultiLangText(from: model.summary),
             title: MultiLangText(from: model.title)
         )

--- a/ios/Sources/Model/FeedItem.swift
+++ b/ios/Sources/Model/FeedItem.swift
@@ -53,9 +53,7 @@ public struct FeedItem: Equatable, Identifiable {
         self.image = Image(from: model.image)
         self.link = model.link
         self.media = Media.from(model.media)
-        self.publishedAt = Date(
-            timeIntervalSince1970: Double(model.publishedAt.toEpochMilliseconds())
-        )
+        self.publishedAt = model.publishedAt.toNSDate()
         self.summary = MultiLangText(from: model.summary)
         self.title = MultiLangText(from: model.title)
         self.publishedDateString = model.publishedDateString()

--- a/ios/Sources/Model/Podcast.swift
+++ b/ios/Sources/Model/Podcast.swift
@@ -40,9 +40,7 @@ public struct Podcast: Equatable, Identifiable {
             image: Image(from: model.image),
             link: model.link,
             media: Media.from(model.media),
-            publishedAt: Date(
-                timeIntervalSince1970: Double(model.publishedAt.toEpochMilliseconds())
-            ),
+            publishedAt: model.publishedAt.toNSDate(),
             summary: MultiLangText(from: model.summary),
             title: MultiLangText(from: model.title)
         )

--- a/ios/Sources/Model/Video.swift
+++ b/ios/Sources/Model/Video.swift
@@ -34,9 +34,7 @@ public struct Video: Equatable, Identifiable {
             image: Image(from: model.image),
             link: model.link,
             media: Media.from(model.media),
-            publishedAt: Date(
-                timeIntervalSince1970: Double(model.publishedAt.toEpochMilliseconds())
-            ),
+            publishedAt: model.publishedAt.toNSDate(),
             summary: MultiLangText(from: model.summary),
             title: MultiLangText(from: model.title)
         )


### PR DESCRIPTION
## Overview (Required)

To keep all conversion between `kotlinx-datetime` and Swift types consistently, export `kotlinx-datetime`'s  [`Converters.kt`](https://github.com/Kotlin/kotlinx-datetime/blob/master/core/darwin/src/Converters.kt) to iOS.

## Links

- https://github.com/Kotlin/kotlinx-datetime