### PR TITLE
[iOS] Update NukeUI to 0.6.1

### DIFF
--- a/ios/DroidKaigi2021.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DroidKaigi2021.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/kean/Nuke.git",
         "state": {
           "branch": null,
-          "revision": "35cd3fa3bcea8becf826d9610c1f5bba8f57b728",
-          "version": "10.2.0"
+          "revision": "69ae6d5b8c4b898450432f94bd35f863d3830cfc",
+          "version": "10.3.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/kean/NukeUI.git",
         "state": {
           "branch": null,
-          "revision": "2e3fd56a135dad891747c83607e98c896162f974",
-          "version": "0.4.0"
+          "revision": "62b55e26eddc2ed59e63377ab877efac4f9e049c",
+          "version": "0.6.1"
         }
       },
       {

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -58,7 +58,7 @@ var package = Package(
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", .exact("0.18.0")),
         .package(name: "Introspect", url: "https://github.com/siteline/SwiftUI-Introspect.git", .upToNextMajor(from: "0.1.3")),
-        .package(url: "https://github.com/kean/NukeUI.git", .exact("0.4.0")),
+        .package(url: "https://github.com/kean/NukeUI.git", .exact("0.6.1")),
     ],
     targets: [
         .target(

--- a/ios/Sources/Component/Avatar/AvatarView.swift
+++ b/ios/Sources/Component/Avatar/AvatarView.swift
@@ -39,21 +39,23 @@ public struct AvatarView: View {
     }
 
     public var body: some View {
-        LazyImage(source: avatarImageURL)
-            .placeholder {
+        LazyImage(source: avatarImageURL) { state in
+            if let image = state.image {
+                image
+            } else if state.error != nil {
+                placeholderView
+            } else {
                 placeholderView
             }
-            .failure {
-                placeholderView
-            }
-            .frame(width: style.size, height: style.size)
-            .background(AssetColor.Background.secondary.color.colorScheme(.light))
-            .overlay(
-                Circle()
-                    .stroke(AssetColor.Separate.image.color, lineWidth: 1)
-            )
-            .clipShape(Circle())
-            .background(Color.clear)
+        }
+        .frame(width: style.size, height: style.size)
+        .background(AssetColor.Background.secondary.color.colorScheme(.light))
+        .overlay(
+            Circle()
+                .stroke(AssetColor.Separate.image.color, lineWidth: 1)
+        )
+        .clipShape(Circle())
+        .background(Color.clear)
     }
 }
 

--- a/ios/Sources/Component/ImageView/ImageView.swift
+++ b/ios/Sources/Component/ImageView/ImageView.swift
@@ -6,7 +6,7 @@ public enum PlaceHolder {
     case noImage
     case noImagePodcast
 
-    var image: Image {
+    var image: SwiftUI.Image {
         switch self {
         case .noImage:
             return AssetImage.noImage.image
@@ -49,17 +49,19 @@ public struct ImageView: View {
     }
 
     public var body: some View {
-        LazyImage(source: imageURL)
-            .placeholder {
+        LazyImage(source: imageURL) { state in
+            if let image = state.image {
+                image
+            } else if state.error != nil {
+                placeholderView
+            } else {
                 placeholderView
             }
-            .failure {
-                placeholderView
-            }
-            .overlay(
-                RoundedRectangle(cornerRadius: 2)
-                    .stroke(AssetColor.Separate.image.color, lineWidth: 1)
-            )
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 2)
+                .stroke(AssetColor.Separate.image.color, lineWidth: 1)
+        )
     }
 }
 


### PR DESCRIPTION
## Issue
- close none

## Overview (Required)
- update NukeUI to 0.6.1
- fix current component because NukeUI 0.4.0 to 0.6.1 has breaking changes

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
