### PR TITLE
[iOS] Add the license list to iOS settings app

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -7,3 +7,7 @@ xcuserdata/
 
 # SwiftGen generated
 Generated/
+
+# LicensePlist generated
+com.mono0926.LicensePlist/
+com.mono0926.LicensePlist.*

--- a/ios/DroidKaigi 2021/Debug.xcodeproj/project.pbxproj
+++ b/ios/DroidKaigi 2021/Debug.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4369C90E267A3922000631D6 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4369C90D267A3922000631D6 /* Settings.bundle */; };
 		80823BBE56026449A5FE87E6 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AD8B7D08C51A116EC6F86327 /* Preview Assets.xcassets */; };
 		8BAA8C7C006D04516B3DC1A0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 938D98FE0EC7B3BB8CBEA8A5 /* Assets.xcassets */; };
 		E821C040265FFEA500C3785D /* AppFeature in Frameworks */ = {isa = PBXBuildFile; productRef = E821C03F265FFEA500C3785D /* AppFeature */; };
@@ -16,6 +17,7 @@
 /* Begin PBXFileReference section */
 		1ACA166CBF9A421538E309E4 /* DroidKaigiMPP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DroidKaigiMPP.framework; path = "../ios-framework/build/xcode-frameworks/DroidKaigiMPP.framework"; sourceTree = "<group>"; };
 		2B29CA0397EABB180818B44B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		4369C90D267A3922000631D6 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		7CF1B5E8B91A5006C726F449 /* DroidKaigi_2021App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DroidKaigi_2021App.swift; sourceTree = "<group>"; };
 		938D98FE0EC7B3BB8CBEA8A5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AD8B7D08C51A116EC6F86327 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -45,6 +47,7 @@
 		223355B1A777710E029FCDFC /* DroidKaigi 2021 */ = {
 			isa = PBXGroup;
 			children = (
+				4369C90D267A3922000631D6 /* Settings.bundle */,
 				938D98FE0EC7B3BB8CBEA8A5 /* Assets.xcassets */,
 				7CF1B5E8B91A5006C726F449 /* DroidKaigi_2021App.swift */,
 				2B29CA0397EABB180818B44B /* Info.plist */,
@@ -135,6 +138,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8BAA8C7C006D04516B3DC1A0 /* Assets.xcassets in Resources */,
+				4369C90E267A3922000631D6 /* Settings.bundle in Resources */,
 				80823BBE56026449A5FE87E6 /* Preview Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/DroidKaigi 2021/DroidKaigi 2021/Settings.bundle/Root.plist
+++ b/ios/DroidKaigi 2021/DroidKaigi 2021/Settings.bundle/Root.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+			<key>Title</key>
+			<string>Licenses</string>
+			<key>File</key>
+			<string>com.mono0926.LicensePlist</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/DroidKaigi 2021/Release.xcodeproj/project.pbxproj
+++ b/ios/DroidKaigi 2021/Release.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4369C908267A10F1000631D6 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4369C907267A10F1000631D6 /* Settings.bundle */; };
 		80823BBE56026449A5FE87E6 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AD8B7D08C51A116EC6F86327 /* Preview Assets.xcassets */; };
 		8BAA8C7C006D04516B3DC1A0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 938D98FE0EC7B3BB8CBEA8A5 /* Assets.xcassets */; };
 		E821C045265FFF8B00C3785D /* AppFeature in Frameworks */ = {isa = PBXBuildFile; productRef = E821C044265FFF8B00C3785D /* AppFeature */; };
@@ -16,6 +17,7 @@
 /* Begin PBXFileReference section */
 		1ACA166CBF9A421538E309E4 /* DroidKaigiMPP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DroidKaigiMPP.framework; path = "../ios-framework/build/xcode-frameworks/DroidKaigiMPP.framework"; sourceTree = "<group>"; };
 		2B29CA0397EABB180818B44B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		4369C907267A10F1000631D6 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		7CF1B5E8B91A5006C726F449 /* DroidKaigi_2021App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DroidKaigi_2021App.swift; sourceTree = "<group>"; };
 		938D98FE0EC7B3BB8CBEA8A5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AD8B7D08C51A116EC6F86327 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -49,6 +51,7 @@
 				7CF1B5E8B91A5006C726F449 /* DroidKaigi_2021App.swift */,
 				2B29CA0397EABB180818B44B /* Info.plist */,
 				1632D25082D97FDCF82D3510 /* Preview Content */,
+				4369C907267A10F1000631D6 /* Settings.bundle */,
 			);
 			path = "DroidKaigi 2021";
 			sourceTree = "<group>";
@@ -88,6 +91,7 @@
 				57B979F2FC459E2182C0AB24 /* Run SwiftLint */,
 				E84C12F72664CEE100D5410C /* Run SwiftGen */,
 				42B134C0F3C46E32AF4355A0 /* Make kotlin framework */,
+				4369C90A267A1207000631D6 /* Generate license list */,
 				5D913506A16C6526B14ED775 /* Sources */,
 				DB796961EB331BDC287C80A9 /* Resources */,
 				E2A67F49BC9729C1C5B9D092 /* Frameworks */,
@@ -135,6 +139,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8BAA8C7C006D04516B3DC1A0 /* Assets.xcassets in Resources */,
+				4369C908267A10F1000631D6 /* Settings.bundle in Resources */,
 				80823BBE56026449A5FE87E6 /* Preview Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -159,6 +164,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "../scripts/create-kmm-framework.sh\n";
+		};
+		4369C90A267A1207000631D6 /* Generate license list */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Generate license list";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "../scripts/generate-license-list.sh\n";
 		};
 		57B979F2FC459E2182C0AB24 /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/DroidKaigi2021.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/DroidKaigi2021.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "APIKit",
+        "repositoryURL": "https://github.com/ishkawa/APIKit.git",
+        "state": {
+          "branch": null,
+          "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
+          "version": "5.2.0"
+        }
+      },
+      {
         "package": "combine-schedulers",
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
@@ -29,12 +38,39 @@
         }
       },
       {
+        "package": "HeliumLogger",
+        "repositoryURL": "https://github.com/Kitura/HeliumLogger.git",
+        "state": {
+          "branch": null,
+          "revision": "55fd2f0b70793017acee853c53cfcf8da0bd8d8d",
+          "version": "1.9.200"
+        }
+      },
+      {
         "package": "Kanna",
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
           "revision": "c657fb9f5827ef138068215c76ad0bb62bbc92da",
           "version": "5.2.4"
+        }
+      },
+      {
+        "package": "LicensePlist",
+        "repositoryURL": "https://github.com/mono0926/LicensePlist.git",
+        "state": {
+          "branch": null,
+          "revision": "38db6f435cc77513a528780d14b1b29daf042439",
+          "version": "3.13.0"
+        }
+      },
+      {
+        "package": "LoggerAPI",
+        "repositoryURL": "https://github.com/Kitura/LoggerAPI.git",
+        "state": {
+          "branch": null,
+          "revision": "e82d34eab3f0b05391082b11ea07d3b70d2f65bb",
+          "version": "1.9.200"
         }
       },
       {
@@ -128,6 +164,24 @@
         }
       },
       {
+        "package": "HTMLEntities",
+        "repositoryURL": "https://github.com/Kitura/swift-html-entities.git",
+        "state": {
+          "branch": null,
+          "revision": "2b14531d0c36dbb7c1c45a4d38db9c2e7898a307",
+          "version": "3.0.200"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
+        }
+      },
+      {
         "package": "SwiftGen",
         "repositoryURL": "https://github.com/SwiftGen/SwiftGen.git",
         "state": {
@@ -179,6 +233,15 @@
           "branch": null,
           "revision": "603974e3909ad4b48ba04aad7e0ceee4f077a518",
           "version": "0.1.0"
+        }
+      },
+      {
+        "package": "Yaml",
+        "repositoryURL": "https://github.com/behrang/YamlSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
+          "version": "3.4.4"
         }
       },
       {

--- a/ios/Tools/Package.resolved
+++ b/ios/Tools/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "APIKit",
+        "repositoryURL": "https://github.com/ishkawa/APIKit.git",
+        "state": {
+          "branch": null,
+          "revision": "c8f5320d84c4c34c0fd965da3c7957819a1ccdd4",
+          "version": "5.2.0"
+        }
+      },
+      {
         "package": "Commander",
         "repositoryURL": "https://github.com/kylef/Commander.git",
         "state": {
@@ -11,12 +20,39 @@
         }
       },
       {
+        "package": "HeliumLogger",
+        "repositoryURL": "https://github.com/Kitura/HeliumLogger.git",
+        "state": {
+          "branch": null,
+          "revision": "55fd2f0b70793017acee853c53cfcf8da0bd8d8d",
+          "version": "1.9.200"
+        }
+      },
+      {
         "package": "Kanna",
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
           "revision": "c657fb9f5827ef138068215c76ad0bb62bbc92da",
           "version": "5.2.4"
+        }
+      },
+      {
+        "package": "LicensePlist",
+        "repositoryURL": "https://github.com/mono0926/LicensePlist.git",
+        "state": {
+          "branch": null,
+          "revision": "38db6f435cc77513a528780d14b1b29daf042439",
+          "version": "3.13.0"
+        }
+      },
+      {
+        "package": "LoggerAPI",
+        "repositoryURL": "https://github.com/Kitura/LoggerAPI.git",
+        "state": {
+          "branch": null,
+          "revision": "e82d34eab3f0b05391082b11ea07d3b70d2f65bb",
+          "version": "1.9.200"
         }
       },
       {
@@ -74,6 +110,24 @@
         }
       },
       {
+        "package": "HTMLEntities",
+        "repositoryURL": "https://github.com/Kitura/swift-html-entities.git",
+        "state": {
+          "branch": null,
+          "revision": "2b14531d0c36dbb7c1c45a4d38db9c2e7898a307",
+          "version": "3.0.200"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
+        }
+      },
+      {
         "package": "SwiftGen",
         "repositoryURL": "https://github.com/SwiftGen/SwiftGen.git",
         "state": {
@@ -107,6 +161,15 @@
           "branch": null,
           "revision": "9183170d20857753d4f331b0ca63f73c60764bf3",
           "version": "5.0.2"
+        }
+      },
+      {
+        "package": "Yaml",
+        "repositoryURL": "https://github.com/behrang/YamlSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "287f5cab7da0d92eb947b5fd8151b203ae04a9a3",
+          "version": "3.4.4"
         }
       },
       {

--- a/ios/Tools/Package.swift
+++ b/ios/Tools/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     products: [
     ],
     dependencies: [
+        .package(url: "https://github.com/mono0926/LicensePlist.git", .exact("3.13.0")),
         .package(url: "https://github.com/SwiftGen/SwiftGen.git", .exact("6.4.0")),
         .package(url: "https://github.com/realm/SwiftLint.git", .exact("0.43.1")),
     ],

--- a/ios/scripts/generate-license-list.sh
+++ b/ios/scripts/generate-license-list.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+xcrun --sdk macosx swift run -c release --package-path Tools license-plist \
+  --package-path DroidKaigi2021.xcworkspace/xcshareddata/swiftpm/Package.resolved \
+  --output-path DroidKaigi\ 2021/DroidKaigi\ 2021/Settings.bundle \
+  --add-version-numbers \
+  --suppress-opening-directory


### PR DESCRIPTION
## Issue
- close #492 

## Overview (Required)
- Add the license list generated by LicensePlist to iOS settings app
  - The license list is generated only when we build the release project

## Links
- https://github.com/mono0926/LicensePlist

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/5673994/122232992-a591bb00-cef6-11eb-9d0e-0c96341d9057.png" width="300" /><br><img src="https://user-images.githubusercontent.com/5673994/122233010-a9bdd880-cef6-11eb-9b26-d87cadc44494.png" width="300" />