### PR TITLE
[iOS] Fix ios-test workflow

### DIFF
--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Show Xcode Version
         run: xcodebuild -version
       - uses: eskatos/gradle-command-action@v1
+        env:
+          CONFIGURATION: Release
         with:
           arguments: "ios-framework:createXCFramework"
           dependencies-cache-key: |
@@ -85,6 +87,6 @@ jobs:
       - name: Generate Strings & Colors & Assets
         working-directory: ./ios
         run: make run-swiftgen
-      - name: Build Test for Debug App
+      - name: Build Test for Release App
         working-directory: ./ios
         run: make build-app-release

--- a/ios/DroidKaigi 2021/Debug.xcodeproj/project.pbxproj
+++ b/ios/DroidKaigi 2021/Debug.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "DroidKaigi 2021/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -239,6 +240,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "DroidKaigi 2021/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;

--- a/ios/DroidKaigi 2021/Release.xcodeproj/project.pbxproj
+++ b/ios/DroidKaigi 2021/Release.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "DroidKaigi 2021/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -257,6 +258,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "DroidKaigi 2021/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;

--- a/ios/Makefile
+++ b/ios/Makefile
@@ -25,9 +25,18 @@ run-swiftgen-generate-xcfilelists:
 create-kmm-framework:
 	./scripts/create-kmm-framework.sh
 
+.PHONE: build-kmm-module
+build-kmm-module:
+	xcodebuild build \
+		-workspace $(WORKSPACE) \
+		-scheme DroidKaigiMPP \
+		-destination platform="$(PLATFORM_IOS)"
+
 # Test App Debug
 .PHONY: test-app-debug
 test-app-debug:
+	make build-kmm-module
+
 	xcodebuild test \
 		-workspace $(WORKSPACE) \
 		-scheme DroidKaigi\ 2021 \
@@ -37,6 +46,8 @@ test-app-debug:
 # Test App Release
 .PHONY: test-app-release
 test-app-release:
+	make build-kmm-module
+
 	xcodebuild test \
 		-workspace $(WORKSPACE) \
 		-scheme DroidKaigi\ 2021 \
@@ -46,6 +57,8 @@ test-app-release:
 # Build App Debug
 .PHONY: build-app-debug
 build-app-debug:
+	make build-kmm-module
+
 	xcodebuild build \
 		-workspace $(WORKSPACE) \
 		-scheme DroidKaigi\ 2021 \
@@ -55,6 +68,8 @@ build-app-debug:
 # Build App Release
 .PHONY: build-app-release
 build-app-release:
+	make build-kmm-module
+
 	xcodebuild build \
 		-workspace $(WORKSPACE) \
 		-scheme DroidKaigi\ 2021 \
@@ -64,6 +79,8 @@ build-app-release:
 # Build Modules
 .PHONY: build-modules
 build-modules:
+	make build-kmm-module
+
 	xcodebuild build \
 		-workspace $(WORKSPACE) \
 		-scheme AboutFeature \

--- a/ios/Makefile
+++ b/ios/Makefile
@@ -25,17 +25,26 @@ run-swiftgen-generate-xcfilelists:
 create-kmm-framework:
 	./scripts/create-kmm-framework.sh
 
-.PHONE: build-kmm-module
-build-kmm-module:
+.PHONE: build-kmm-module-debug
+build-kmm-module-debug:
 	xcodebuild build \
 		-workspace $(WORKSPACE) \
 		-scheme DroidKaigiMPP \
+		-configuration Debug \
+		-destination platform="$(PLATFORM_IOS)"
+
+.PHONE: build-kmm-module-release
+build-kmm-module-release:
+	xcodebuild build \
+		-workspace $(WORKSPACE) \
+		-scheme DroidKaigiMPP \
+		-configuration Release \
 		-destination platform="$(PLATFORM_IOS)"
 
 # Test App Debug
 .PHONY: test-app-debug
 test-app-debug:
-	make build-kmm-module
+	make build-kmm-module-debug
 
 	xcodebuild test \
 		-workspace $(WORKSPACE) \
@@ -46,7 +55,7 @@ test-app-debug:
 # Test App Release
 .PHONY: test-app-release
 test-app-release:
-	make build-kmm-module
+	make build-kmm-module-release
 
 	xcodebuild test \
 		-workspace $(WORKSPACE) \
@@ -57,7 +66,7 @@ test-app-release:
 # Build App Debug
 .PHONY: build-app-debug
 build-app-debug:
-	make build-kmm-module
+	make build-kmm-module-debug
 
 	xcodebuild build \
 		-workspace $(WORKSPACE) \
@@ -68,7 +77,7 @@ build-app-debug:
 # Build App Release
 .PHONY: build-app-release
 build-app-release:
-	make build-kmm-module
+	make build-kmm-module-release
 
 	xcodebuild build \
 		-workspace $(WORKSPACE) \
@@ -79,7 +88,7 @@ build-app-release:
 # Build Modules
 .PHONY: build-modules
 build-modules:
-	make build-kmm-module
+	make build-kmm-module-debug
 
 	xcodebuild build \
 		-workspace $(WORKSPACE) \

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -54,6 +54,10 @@ var package = Package(
             name: "Utility",
             targets: ["Utility"]
         ),
+        .library(
+            name: "DroidKaigiMPP",
+            targets: ["DroidKaigiMPP"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", .exact("0.19.0")),


### PR DESCRIPTION
## Issue
- close #502 

## Overview (Required)
- Build DroidKaigiMPP first 
Workaround for a bug (?) of `xcodebuild` which does not process `DroidkaigiMPP.xcframework` even the target depends on it.
- Separate build-kmm-module to debug and release
- Exclude arm64 for simulator since KMM does not support it yet

## Links
- Verified [here](https://github.com/myihsan/conference-app-2021/pull/1/checks?check_run_id=2850898265)

