### PR TITLE
[iOS] Remove unnecessary BuildPhase

### DIFF
--- a/ios/DroidKaigi 2021/Debug.xcodeproj/project.pbxproj
+++ b/ios/DroidKaigi 2021/Debug.xcodeproj/project.pbxproj
@@ -89,8 +89,6 @@
 			buildConfigurationList = 18B9A2E0D7808713228AF94B /* Build configuration list for PBXNativeTarget "DroidKaigi 2021" */;
 			buildPhases = (
 				57B979F2FC459E2182C0AB24 /* Run SwiftLint */,
-				E84C12F32664CE1C00D5410C /* Run SwiftGen */,
-				42B134C0F3C46E32AF4355A0 /* Make kotlin framework */,
 				5D913506A16C6526B14ED775 /* Sources */,
 				DB796961EB331BDC287C80A9 /* Resources */,
 				E2A67F49BC9729C1C5B9D092 /* Frameworks */,
@@ -146,24 +144,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		42B134C0F3C46E32AF4355A0 /* Make kotlin framework */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Make kotlin framework";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "../scripts/create-kmm-framework.sh\n";
-		};
 		57B979F2FC459E2182C0AB24 /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -181,26 +161,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "../scripts/lint.sh\n";
-		};
-		E84C12F32664CE1C00D5410C /* Run SwiftGen */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"$(SRCROOT)/../XCFileLists/SwiftGenInput.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "Run SwiftGen";
-			outputFileListPaths = (
-				"$(SRCROOT)/../XCFileLists/SwiftGenOutput.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "../scripts/swiftgen.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/DroidKaigi 2021/Release.xcodeproj/project.pbxproj
+++ b/ios/DroidKaigi 2021/Release.xcodeproj/project.pbxproj
@@ -89,8 +89,6 @@
 			buildConfigurationList = 18B9A2E0D7808713228AF94B /* Build configuration list for PBXNativeTarget "DroidKaigi 2021" */;
 			buildPhases = (
 				57B979F2FC459E2182C0AB24 /* Run SwiftLint */,
-				E84C12F72664CEE100D5410C /* Run SwiftGen */,
-				42B134C0F3C46E32AF4355A0 /* Make kotlin framework */,
 				4369C90A267A1207000631D6 /* Generate license list */,
 				5D913506A16C6526B14ED775 /* Sources */,
 				DB796961EB331BDC287C80A9 /* Resources */,
@@ -147,24 +145,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		42B134C0F3C46E32AF4355A0 /* Make kotlin framework */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Make kotlin framework";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "../scripts/create-kmm-framework.sh\n";
-		};
 		4369C90A267A1207000631D6 /* Generate license list */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -200,26 +180,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "../scripts/lint.sh\n";
-		};
-		E84C12F72664CEE100D5410C /* Run SwiftGen */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"$(SRCROOT)/../XCFileLists/SwiftGenInput.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "Run SwiftGen";
-			outputFileListPaths = (
-				"$(SRCROOT)/../XCFileLists/SwiftGenOutput.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "../scripts/swiftgen.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,7 +1,8 @@
 # DroidKaigi 2021 iOS Application
 
 ## Get started
-- Run `$ make open` to open this project.
+1. Run `$ make run-swiftgen` and `$ make create-kmm-framework`
+2. Run `$ make open` to open this project.
 
 ### How to preview SwiftUI View
 


### PR DESCRIPTION
## Issue
- close none

## Overview (Required)
- Remove unnecessary BuildPhases
  - SwiftGen
  - Create KMM Framework
- Remove it because these script executed after build completed. it is so late.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
