### PR TITLE
[iOS][Proposal] Refactor FeedItem to a protocol

### DIFF
--- a/ios/Sources/MediaFeature/MediaDetail.swift
+++ b/ios/Sources/MediaFeature/MediaDetail.swift
@@ -9,7 +9,7 @@ struct MediaDetail: View {
 
     struct ViewState: Equatable {
         var title: String
-        var feedItems: [FeedContent]
+        var feedContents: [FeedContent]
     }
 
     var body: some View {
@@ -23,7 +23,7 @@ struct MediaDetail: View {
 struct MediaDetail_Previews: PreviewProvider {
     static var previews: some View {
         MediaDetail(store: .init(
-            initialState: .init(title: "Blog", feedItems: []),
+            initialState: .init(title: "Blog", feedContents: []),
             reducer: .empty,
             environment: {}
         ))

--- a/ios/Sources/MediaFeature/MediaFeature.swift
+++ b/ios/Sources/MediaFeature/MediaFeature.swift
@@ -95,13 +95,16 @@ public let mediaReducer = Reducer<MediaState, MediaAction, MediaEnvironment>.com
             var videos: [FeedContent] = .init()
             var podcasts: [FeedContent] = .init()
             for content in contents {
-                switch content.item {
-                case .blog:
+                switch content.item.wrappedValue {
+                case is Blog:
                     blogs.append(content)
-                case .podcast:
+                case is Video:
                     videos.append(content)
-                case .video:
+                case is Podcast:
                     podcasts.append(content)
+                default:
+                    assertionFailure("Unexpected FeedItem: (\(content.item.wrappedValue)")
+                    break
                 }
             }
             if var listState = (/MediaState.initialized).extract(from: state) {
@@ -129,7 +132,7 @@ extension MediaListState {
 
 extension Array where Element == FeedContent {
     static let mockBlogs: Self = [
-        .blog(.init(
+        Blog(
             id: "0",
             image: .init(largeURLString: "", smallURLString: "", standardURLString: ""),
             link: "",
@@ -139,8 +142,8 @@ extension Array where Element == FeedContent {
             title: .init(enTitle: "", jaTitle: "DroidKaigi 2020でのCodelabsについて"),
             author: .init(link: "", name: ""),
             language: ""
-        )),
-        .blog(.init(
+        ),
+        Blog(
             id: "1",
             image: .init(largeURLString: "", smallURLString: "", standardURLString: ""),
             link: "",
@@ -150,12 +153,13 @@ extension Array where Element == FeedContent {
             title: .init(enTitle: "", jaTitle: "DroidKaigi 2020 Codelabs"),
             author: .init(link: "", name: ""),
             language: ""
-        )),
+        ),
     ]
+    .map(AnyFeedItem.init)
     .map { .init(item: $0, isFavorited: false) }
 
     static let mockVideos: Self = [
-        .video(.init(
+        Video(
             id: "0",
             image: .init(largeURLString: "", smallURLString: "", standardURLString: ""),
             link: "",
@@ -163,8 +167,8 @@ extension Array where Element == FeedContent {
             publishedAt: .init(),
             summary: .init(enTitle: "", jaTitle: ""),
             title: .init(enTitle: "", jaTitle: "DroidKaigi 2020 Lite - KotlinのDelegated Propertiesを活用してAndroidアプリ開発をもっと便利にする / chibatching [JA]")
-        )),
-        .video(.init(
+        ),
+        Video(
             id: "1",
             image: .init(largeURLString: "", smallURLString: "", standardURLString: ""),
             link: "",
@@ -172,12 +176,13 @@ extension Array where Element == FeedContent {
             publishedAt: .init(),
             summary: .init(enTitle: "", jaTitle: ""),
             title: .init(enTitle: "", jaTitle: "DroidKaigi 2020 Lite - Day 2 Night Session")
-        )),
+        ),
     ]
+    .map(AnyFeedItem.init)
     .map { .init(item: $0, isFavorited: false) }
 
     static let mockPodcasts: Self = [
-        .podcast(.init(
+        Podcast(
             id: "0",
             image: .init(largeURLString: "", smallURLString: "", standardURLString: ""),
             link: "",
@@ -187,8 +192,8 @@ extension Array where Element == FeedContent {
             speakers: [],
             summary: .init(enTitle: "", jaTitle: ""),
             title: .init(enTitle: "", jaTitle: "2. Android 11 Talks")
-        )),
-        .podcast(.init(
+        ),
+        Podcast(
             id: "1",
             image: .init(largeURLString: "", smallURLString: "", standardURLString: ""),
             link: "",
@@ -198,7 +203,8 @@ extension Array where Element == FeedContent {
             speakers: [],
             summary: .init(enTitle: "", jaTitle: ""),
             title: .init(enTitle: "", jaTitle: "5. Notificiationよもやま話")
-        )),
+        ),
     ]
+    .map(AnyFeedItem.init)
     .map { .init(item: $0, isFavorited: false) }
 }

--- a/ios/Sources/MediaFeature/MediaListView.swift
+++ b/ios/Sources/MediaFeature/MediaListView.swift
@@ -126,13 +126,13 @@ private extension MediaDetail.ViewState {
         switch mediaType {
         case .blog:
             title = L10n.MediaScreen.Section.Blog.title
-            feedItems = state.blogs
+            feedContents = state.blogs
         case .video:
             title = L10n.MediaScreen.Section.Video.title
-            feedItems = state.videos
+            feedContents = state.videos
         case .podcast:
             title = L10n.MediaScreen.Section.Podcast.title
-            feedItems = state.podcasts
+            feedContents = state.podcasts
         }
     }
 }

--- a/ios/Sources/MediaFeature/MediaSection.swift
+++ b/ios/Sources/MediaFeature/MediaSection.swift
@@ -24,14 +24,14 @@ struct MediaSection: View {
                 )
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(spacing: 0) {
-                        ForEach(viewStore.state) { item in
-                            let feedItem = item.feedItem
+                        ForEach(viewStore.state) { content in
+                            let item = content.item
                             MediumCard(
-                                title: feedItem.title.get(by: .ja),
-                                imageURL: URL(string: feedItem.image.standardURLString),
-                                tag: feedItem.media,
-                                date: feedItem.publishedAt,
-                                isFavorited: item.isFavorited,
+                                title: item.title.get(by: .ja),
+                                imageURL: URL(string: item.image.standardURLString),
+                                tag: item.media,
+                                date: item.publishedAt,
+                                isFavorited: content.isFavorited,
                                 tapAction: {},
                                 tapFavoriteAction: {}
                             )

--- a/ios/Sources/Model/Blog.swift
+++ b/ios/Sources/Model/Blog.swift
@@ -47,8 +47,8 @@ public struct Blog: FeedItem, Equatable {
 }
 
 public extension Blog {
-    var kmmModel: DroidKaigiMPP.FeedItem {
-        DroidKaigiMPP.FeedItem.Blog(
+    var kmmModel: DroidKaigiMPP.FeedItem.Blog {
+        .init(
             id: id,
             publishedAt: ConvertersKt.toKotlinInstant(publishedAt),
             image: image.kmmModel,
@@ -60,4 +60,6 @@ public extension Blog {
             author: author.kmmModel
         )
     }
+
+    var _kmmModel: DroidKaigiMPP.FeedItem { kmmModel }  // swiftlint:disable:this identifier_name
 }

--- a/ios/Sources/Model/Blog.swift
+++ b/ios/Sources/Model/Blog.swift
@@ -1,14 +1,15 @@
 import DroidKaigiMPP
 
-@dynamicMemberLookup
-public struct Blog: Equatable, Identifiable {
-    public var feedItem: FeedItem
+public struct Blog: FeedItem, Equatable {
+    public var id: String
+    public var image: Image
+    public var link: String
+    public var media: Media
+    public var publishedAt: Date
+    public var summary: MultiLangText
+    public var title: MultiLangText
     public var author: Author
     public var language: String
-
-    public var id: String {
-        feedItem.id
-    }
 
     public init(
         id: String,
@@ -21,48 +22,40 @@ public struct Blog: Equatable, Identifiable {
         author: Author,
         language: String
     ) {
-        self.feedItem = .init(
-            id: id,
-            image: image,
-            link: link,
-            media: media,
-            publishedAt: publishedAt,
-            summary: summary,
-            title: title
-        )
+        self.id = id
+        self.image = image
+        self.link = link
+        self.media = media
+        self.publishedAt = publishedAt
+        self.summary = summary
+        self.title = title
         self.author = author
         self.language = language
     }
 
     public init(from model: DroidKaigiMPP.FeedItem.Blog) {
-        self.feedItem = .init(
-            id: model.id,
-            image: Image(from: model.image),
-            link: model.link,
-            media: Media.from(model.media),
-            publishedAt: model.publishedAt.toNSDate(),
-            summary: MultiLangText(from: model.summary),
-            title: MultiLangText(from: model.title)
-        )
+        self.id = model.id
+        self.image = Image(from: model.image)
+        self.link = model.link
+        self.media = Media.from(model.media)
+        self.publishedAt = model.publishedAt.toNSDate()
+        self.summary = MultiLangText(from: model.summary)
+        self.title = MultiLangText(from: model.title)
         self.author = Author(from: model.author)
         self.language = model.language
-    }
-
-    public subscript<T>(dynamicMember keyPath: KeyPath<FeedItem, T>) -> T {
-        self.feedItem[keyPath: keyPath]
     }
 }
 
 public extension Blog {
-    var kmmModel: DroidKaigiMPP.FeedItem.Blog {
-        .init(
+    var kmmModel: DroidKaigiMPP.FeedItem {
+        DroidKaigiMPP.FeedItem.Blog(
             id: id,
-            publishedAt: ConvertersKt.toKotlinInstant(feedItem.publishedAt),
-            image: feedItem.image.kmmModel,
-            media: feedItem.media.kmmModel,
-            title: feedItem.title.kmmModel,
-            summary: feedItem.summary.kmmModel,
-            link: feedItem.link,
+            publishedAt: ConvertersKt.toKotlinInstant(publishedAt),
+            image: image.kmmModel,
+            media: media.kmmModel,
+            title: title.kmmModel,
+            summary: summary.kmmModel,
+            link: link,
             language: language,
             author: author.kmmModel
         )

--- a/ios/Sources/Model/FeedContent.swift
+++ b/ios/Sources/Model/FeedContent.swift
@@ -1,29 +1,17 @@
 import DroidKaigiMPP
 
 public struct FeedContent: Equatable, Identifiable {
-    public var item: FeedItemType
+    public var item: AnyFeedItem
     public var isFavorited: Bool
-    public var feedItem: FeedItem {
-        switch item {
-        case let .blog(blog):
-            return blog.feedItem
-        case let .podcast(podcast):
-            return podcast.feedItem
-        case let .video(video):
-            return video.feedItem
-        }
-    }
-    public var id: String {
-        feedItem.id
-    }
+    public var id: String { item.id }
 
-    public init(item: FeedItemType, isFavorited: Bool) {
+    public init(item: AnyFeedItem, isFavorited: Bool) {
         self.item = item
         self.isFavorited = isFavorited
     }
 
     public init?(from model: DroidKaigiMPP.KotlinPair<DroidKaigiMPP.FeedItem, KotlinBoolean>) {
-        guard let item = model.first.flatMap(FeedItemType.from(_:)) else { return nil }
+        guard let item = model.first.flatMap(AnyFeedItem.from(_:)) else { return nil }
         self.item = item
         self.isFavorited = model.second?.boolValue ?? false
     }

--- a/ios/Sources/Model/FeedItem.swift
+++ b/ios/Sources/Model/FeedItem.swift
@@ -35,7 +35,7 @@ public struct AnyFeedItem: Equatable {
     }
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        switch (lhs, rhs) {
+        switch (lhs.wrappedValue, rhs.wrappedValue) {
         case let (lhs, rhs) as (Blog, Blog):
             return lhs == rhs
         case let (lhs, rhs) as  (Video, Video):

--- a/ios/Sources/Model/FeedItem.swift
+++ b/ios/Sources/Model/FeedItem.swift
@@ -8,13 +8,14 @@ public protocol FeedItem {
     var publishedAt: Date { get set }
     var summary: MultiLangText { get set }
     var title: MultiLangText { get set }
-    var kmmModel: DroidKaigiMPP.FeedItem { get }
+    var _kmmModel: DroidKaigiMPP.FeedItem { get } // swiftlint:disable:this identifier_name
 }
 
 @dynamicMemberLookup
 public struct AnyFeedItem: Equatable {
 
     public var wrappedValue: FeedItem
+    public var kmmModel: DroidKaigiMPP.FeedItem { wrappedValue._kmmModel }
 
     public init(_ feedItem: FeedItem) {
         self.wrappedValue = feedItem

--- a/ios/Sources/Model/FeedItem.swift
+++ b/ios/Sources/Model/FeedItem.swift
@@ -1,72 +1,52 @@
 import DroidKaigiMPP
 
-public enum FeedItemType: Equatable {
-    case blog(Blog)
-    case podcast(Podcast)
-    case video(Video)
+public protocol FeedItem {
+    var id: String { get set }
+    var image: Image { get set }
+    var link: String { get set }
+    var media: Media { get set }
+    var publishedAt: Date { get set }
+    var summary: MultiLangText { get set }
+    var title: MultiLangText { get set }
+    var kmmModel: DroidKaigiMPP.FeedItem { get }
+}
 
-    public var item: DroidKaigiMPP.FeedItem {
-        switch self {
-        case let .blog(blog):
-            return blog.kmmModel
-        case let .podcast(podcast):
-            return podcast.kmmModel
-        case let .video(video):
-            return video.kmmModel
-        }
+@dynamicMemberLookup
+public struct AnyFeedItem: Equatable {
+
+    public var wrappedValue: FeedItem
+
+    public init(_ feedItem: FeedItem) {
+        self.wrappedValue = feedItem
     }
 
-    public static func from(_ model: DroidKaigiMPP.FeedItem) -> FeedItemType? {
+    public static func from(_ model: DroidKaigiMPP.FeedItem) -> AnyFeedItem? {
         switch model {
         case let blog as DroidKaigiMPP.FeedItem.Blog:
-            return .blog(Blog(from: blog))
+            return .init(Blog(from: blog))
         case let podcast as DroidKaigiMPP.FeedItem.Podcast:
-            return .podcast(Podcast(from: podcast))
+            return .init(Podcast(from: podcast))
         case let video as DroidKaigiMPP.FeedItem.Video:
-            return .video(Video(from: video))
+            return .init(Video(from: video))
         default:
             return nil
         }
     }
-}
 
-public struct FeedItem: Equatable, Identifiable {
-    public var id: String
-    public var image: Image
-    public var link: String
-    public var media: Media
-    public var publishedAt: Date
-    public var summary: MultiLangText
-    public var title: MultiLangText
-    public var publishedDateString: String?
-
-    public init(
-        id: String,
-        image: Image,
-        link: String,
-        media: Media,
-        publishedAt: Date,
-        summary: MultiLangText,
-        title: MultiLangText
-    ) {
-        self.id = id
-        self.image = image
-        self.link = link
-        self.media = media
-        self.publishedAt = publishedAt
-        self.summary = summary
-        self.title = title
-        self.publishedDateString = nil
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case let (lhs, rhs) as (Blog, Blog):
+            return lhs == rhs
+        case let (lhs, rhs) as  (Video, Video):
+            return lhs == rhs
+        case let (lhs, rhs) as  (Podcast, Podcast):
+            return lhs == rhs
+        default:
+            return false
+        }
     }
 
-    public init(from model: DroidKaigiMPP.FeedItem) {
-        self.id = model.id
-        self.image = Image(from: model.image)
-        self.link = model.link
-        self.media = Media.from(model.media)
-        self.publishedAt = model.publishedAt.toNSDate()
-        self.summary = MultiLangText(from: model.summary)
-        self.title = MultiLangText(from: model.title)
-        self.publishedDateString = model.publishedDateString()
+    public subscript<T>(dynamicMember keyPath: KeyPath<FeedItem, T>) -> T {
+        self.wrappedValue[keyPath: keyPath]
     }
 }

--- a/ios/Sources/Model/Podcast.swift
+++ b/ios/Sources/Model/Podcast.swift
@@ -47,8 +47,8 @@ public struct Podcast: FeedItem, Equatable {
 }
 
 public extension Podcast {
-    var kmmModel: DroidKaigiMPP.FeedItem {
-        DroidKaigiMPP.FeedItem.Podcast(
+    var kmmModel: DroidKaigiMPP.FeedItem.Podcast {
+        .init(
             id: id,
             publishedAt: ConvertersKt.toKotlinInstant(publishedAt),
             image: image.kmmModel,
@@ -60,4 +60,6 @@ public extension Podcast {
             podcastLink: podcastLink
         )
     }
+
+    var _kmmModel: DroidKaigiMPP.FeedItem { kmmModel }  // swiftlint:disable:this identifier_name
 }

--- a/ios/Sources/Model/Podcast.swift
+++ b/ios/Sources/Model/Podcast.swift
@@ -1,12 +1,13 @@
 import DroidKaigiMPP
 
-@dynamicMemberLookup
-public struct Podcast: Equatable, Identifiable {
-    public var feedItem: FeedItem
-
-    public var id: String {
-        feedItem.id
-    }
+public struct Podcast: FeedItem, Equatable {
+    public var id: String
+    public var image: Image
+    public var link: String
+    public var media: Media
+    public var publishedAt: Date
+    public var summary: MultiLangText
+    public var title: MultiLangText
     public var podcastLink: String
     public var speakers: [Speaker]
 
@@ -21,48 +22,40 @@ public struct Podcast: Equatable, Identifiable {
         summary: MultiLangText,
         title: MultiLangText
     ) {
-        self.feedItem = .init(
-            id: id,
-            image: image,
-            link: link,
-            media: media,
-            publishedAt: publishedAt,
-            summary: summary,
-            title: title
-        )
+        self.id = id
+        self.image = image
+        self.link = link
+        self.media = media
+        self.publishedAt = publishedAt
+        self.summary = summary
+        self.title = title
         self.podcastLink = podcastLink
         self.speakers = speakers
     }
 
     public init(from model: DroidKaigiMPP.FeedItem.Podcast) {
-        self.feedItem = .init(
-            id: model.id,
-            image: Image(from: model.image),
-            link: model.link,
-            media: Media.from(model.media),
-            publishedAt: model.publishedAt.toNSDate(),
-            summary: MultiLangText(from: model.summary),
-            title: MultiLangText(from: model.title)
-        )
+        self.id = model.id
+        self.image = Image(from: model.image)
+        self.link = model.link
+        self.media = Media.from(model.media)
+        self.publishedAt = model.publishedAt.toNSDate()
+        self.summary = MultiLangText(from: model.summary)
+        self.title = MultiLangText(from: model.title)
         self.podcastLink = model.podcastLink
         self.speakers = model.speakers.map(Speaker.init(from:))
-    }
-
-    public subscript<T>(dynamicMember keyPath: KeyPath<FeedItem, T>) -> T {
-        self.feedItem[keyPath: keyPath]
     }
 }
 
 public extension Podcast {
-    var kmmModel: DroidKaigiMPP.FeedItem.Podcast {
-        .init(
+    var kmmModel: DroidKaigiMPP.FeedItem {
+        DroidKaigiMPP.FeedItem.Podcast(
             id: id,
-            publishedAt: ConvertersKt.toKotlinInstant(feedItem.publishedAt),
-            image: feedItem.image.kmmModel,
-            media: feedItem.media.kmmModel,
-            title: feedItem.title.kmmModel,
-            summary: feedItem.summary.kmmModel,
-            link: feedItem.link,
+            publishedAt: ConvertersKt.toKotlinInstant(publishedAt),
+            image: image.kmmModel,
+            media: media.kmmModel,
+            title: title.kmmModel,
+            summary: summary.kmmModel,
+            link: link,
             speakers: speakers.map(\.kmmModel),
             podcastLink: podcastLink
         )

--- a/ios/Sources/Model/Video.swift
+++ b/ios/Sources/Model/Video.swift
@@ -39,8 +39,8 @@ public struct Video: FeedItem, Equatable {
 }
 
 public extension Video {
-    var kmmModel: DroidKaigiMPP.FeedItem {
-        DroidKaigiMPP.FeedItem.Video(
+    var kmmModel: DroidKaigiMPP.FeedItem.Video {
+        .init(
             id: id,
             publishedAt: ConvertersKt.toKotlinInstant(publishedAt),
             image: image.kmmModel,
@@ -50,4 +50,6 @@ public extension Video {
             link: link
         )
     }
+
+    var _kmmModel: DroidKaigiMPP.FeedItem { kmmModel }  // swiftlint:disable:this identifier_name
 }

--- a/ios/Sources/Model/Video.swift
+++ b/ios/Sources/Model/Video.swift
@@ -1,12 +1,13 @@
 import DroidKaigiMPP
 
-@dynamicMemberLookup
-public struct Video: Equatable, Identifiable {
-    public var feedItem: FeedItem
-
-    public var id: String {
-        feedItem.id
-    }
+public struct Video: FeedItem, Equatable {
+    public var id: String
+    public var image: Image
+    public var link: String
+    public var media: Media
+    public var publishedAt: Date
+    public var summary: MultiLangText
+    public var title: MultiLangText
 
     public init(
         id: String,
@@ -17,44 +18,36 @@ public struct Video: Equatable, Identifiable {
         summary: MultiLangText,
         title: MultiLangText
     ) {
-        self.feedItem = .init(
-            id: id,
-            image: image,
-            link: link,
-            media: media,
-            publishedAt: publishedAt,
-            summary: summary,
-            title: title
-        )
+        self.id = id
+        self.image = image
+        self.link = link
+        self.media = media
+        self.publishedAt = publishedAt
+        self.summary = summary
+        self.title = title
     }
 
     public init(from model: DroidKaigiMPP.FeedItem.Video) {
-        self.feedItem = .init(
-            id: model.id,
-            image: Image(from: model.image),
-            link: model.link,
-            media: Media.from(model.media),
-            publishedAt: model.publishedAt.toNSDate(),
-            summary: MultiLangText(from: model.summary),
-            title: MultiLangText(from: model.title)
-        )
-    }
-
-    public subscript<T>(dynamicMember keyPath: KeyPath<FeedItem, T>) -> T {
-        self.feedItem[keyPath: keyPath]
+        self.id = model.id
+        self.image = Image(from: model.image)
+        self.link = model.link
+        self.media = Media.from(model.media)
+        self.publishedAt = model.publishedAt.toNSDate()
+        self.summary = MultiLangText(from: model.summary)
+        self.title = MultiLangText(from: model.title)
     }
 }
 
 public extension Video {
-    var kmmModel: DroidKaigiMPP.FeedItem.Video {
-        .init(
+    var kmmModel: DroidKaigiMPP.FeedItem {
+        DroidKaigiMPP.FeedItem.Video(
             id: id,
-            publishedAt: ConvertersKt.toKotlinInstant(feedItem.publishedAt),
-            image: feedItem.image.kmmModel,
-            media: feedItem.media.kmmModel,
-            title: feedItem.title.kmmModel,
-            summary: feedItem.summary.kmmModel,
-            link: feedItem.link
+            publishedAt: ConvertersKt.toKotlinInstant(publishedAt),
+            image: image.kmmModel,
+            media: media.kmmModel,
+            title: title.kmmModel,
+            summary: summary.kmmModel,
+            link: link
         )
     }
 }

--- a/ios/Sources/Repository/FeedRepository.swift
+++ b/ios/Sources/Repository/FeedRepository.swift
@@ -35,7 +35,7 @@ public struct FeedRepository: FeedRepositoryProtocol, KMMRepositoryProtocol {
 
     public func addFavorite(feedItem: AnyFeedItem) -> AnyPublisher<Void, KotlinError> {
         Future<Void, KotlinError> { promise in
-            repository.addFavorite(feedItem: feedItem.wrappedValue.kmmModel)
+            repository.addFavorite(feedItem: feedItem.kmmModel)
                 .subscribe(scope: scopeProvider.scope) { _ in
                     promise(.success(()))
                 } onFailure: {
@@ -47,7 +47,7 @@ public struct FeedRepository: FeedRepositoryProtocol, KMMRepositoryProtocol {
 
     public func removeFavorite(feedItem: AnyFeedItem) -> AnyPublisher<Void, KotlinError> {
         Future<Void, KotlinError> { promise in
-            repository.removeFavorite(feedItem: feedItem.wrappedValue.kmmModel)
+            repository.removeFavorite(feedItem: feedItem.kmmModel)
                 .subscribe(scope: scopeProvider.scope) { _ in
                     promise(.success(()))
                 } onFailure: {

--- a/ios/Sources/Repository/FeedRepository.swift
+++ b/ios/Sources/Repository/FeedRepository.swift
@@ -4,8 +4,8 @@ import Model
 
 public protocol FeedRepositoryProtocol {
     func feedContents() -> AnyPublisher<[FeedContent], KotlinError>
-    func addFavorite(feedItem: Model.FeedItemType) -> AnyPublisher<Void, KotlinError>
-    func removeFavorite(feedItem: Model.FeedItemType) -> AnyPublisher<Void, KotlinError>
+    func addFavorite(feedItem: AnyFeedItem) -> AnyPublisher<Void, KotlinError>
+    func removeFavorite(feedItem: AnyFeedItem) -> AnyPublisher<Void, KotlinError>
 }
 
 public struct FeedRepository: FeedRepositoryProtocol, KMMRepositoryProtocol {
@@ -33,9 +33,9 @@ public struct FeedRepository: FeedRepositoryProtocol, KMMRepositoryProtocol {
         .eraseToAnyPublisher()
     }
 
-    public func addFavorite(feedItem: Model.FeedItemType) -> AnyPublisher<Void, KotlinError> {
+    public func addFavorite(feedItem: AnyFeedItem) -> AnyPublisher<Void, KotlinError> {
         Future<Void, KotlinError> { promise in
-            repository.addFavorite(feedItem: feedItem.item)
+            repository.addFavorite(feedItem: feedItem.wrappedValue.kmmModel)
                 .subscribe(scope: scopeProvider.scope) { _ in
                     promise(.success(()))
                 } onFailure: {
@@ -45,9 +45,9 @@ public struct FeedRepository: FeedRepositoryProtocol, KMMRepositoryProtocol {
         }.eraseToAnyPublisher()
     }
 
-    public func removeFavorite(feedItem: Model.FeedItemType) -> AnyPublisher<Void, KotlinError> {
+    public func removeFavorite(feedItem: AnyFeedItem) -> AnyPublisher<Void, KotlinError> {
         Future<Void, KotlinError> { promise in
-            repository.removeFavorite(feedItem: feedItem.item)
+            repository.removeFavorite(feedItem: feedItem.wrappedValue.kmmModel)
                 .subscribe(scope: scopeProvider.scope) { _ in
                     promise(.success(()))
                 } onFailure: {


### PR DESCRIPTION
## Issue

In the major cases, the sealed class in Kotlin should be treated as an enumeration in Swift to be exhaustive in `switch`.
However, for `FeedItem`, we need the common properties to display them in sequence, so we have to extract the associated value by `switch` every time we access a property if we treat it as an enumeration.

Therefore, it may be better to treat it as a protocol.

## Overview (Required)

- Refactor `FeedItem` to a protocol
- Use `AnyFeedItem` to wrap values of types implemented `FeedItem` in order to implement `Equatable` without losing the capability to use without generic (for example when `FeedItem` inherited `Equatable` ).