### PR TITLE
Adjust FeedRepository for the iOS project

### DIFF
--- a/data/repository/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/FeedRepositoryImpl.kt
+++ b/data/repository/src/commonMain/kotlin/io/github/droidkaigi/feeder/data/FeedRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package io.github.droidkaigi.feeder.data
 
 import io.github.droidkaigi.feeder.FeedContents
-import io.github.droidkaigi.feeder.FeedItem
 import io.github.droidkaigi.feeder.repository.FeedRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -24,11 +23,11 @@ open class FeedRepositoryImpl(
         feedItemDao.insert(newFeeds)
     }
 
-    override suspend fun addFavorite(feedItem: FeedItem) {
-        dataStore.addFavorite(feedItem.id)
+    override suspend fun addFavorite(id: String) {
+        dataStore.addFavorite(id)
     }
 
-    override suspend fun removeFavorite(feedItem: FeedItem) {
-        dataStore.removeFavorite(feedItem.id)
+    override suspend fun removeFavorite(id: String) {
+        dataStore.removeFavorite(id)
     }
 }

--- a/ios-framework/src/iosMain/kotlin/io/github/droidkaigi/feeder/repository/IosFeedRepository.kt
+++ b/ios-framework/src/iosMain/kotlin/io/github/droidkaigi/feeder/repository/IosFeedRepository.kt
@@ -1,15 +1,14 @@
 package io.github.droidkaigi.feeder.repository
 
 import io.github.droidkaigi.feeder.FeedContents
-import io.github.droidkaigi.feeder.FeedItem
 import io.github.droidkaigi.feeder.NonNullFlowWrapper
 import io.github.droidkaigi.feeder.NonNullSuspendWrapper
 
 interface IosFeedRepository {
     fun feedContents(): NonNullFlowWrapper<FeedContents>
     fun refresh(): NonNullSuspendWrapper<Unit>
-    fun addFavorite(feedItem: FeedItem): NonNullSuspendWrapper<Unit>
-    fun removeFavorite(feedItem: FeedItem): NonNullSuspendWrapper<Unit>
+    fun addFavorite(id: String): NonNullSuspendWrapper<Unit>
+    fun removeFavorite(id: String): NonNullSuspendWrapper<Unit>
 }
 
 class IosFeedRepositoryImpl(
@@ -27,15 +26,15 @@ class IosFeedRepositoryImpl(
         }
     }
 
-    override fun addFavorite(feedItem: FeedItem): NonNullSuspendWrapper<Unit> {
+    override fun addFavorite(id: String): NonNullSuspendWrapper<Unit> {
         return NonNullSuspendWrapper {
-            feedRepository.addFavorite(feedItem)
+            feedRepository.addFavorite(id)
         }
     }
 
-    override fun removeFavorite(feedItem: FeedItem): NonNullSuspendWrapper<Unit> {
+    override fun removeFavorite(id: String): NonNullSuspendWrapper<Unit> {
         return NonNullSuspendWrapper {
-            feedRepository.removeFavorite(feedItem)
+            feedRepository.removeFavorite(id)
         }
     }
 }

--- a/ios/Sources/Model/Author.swift
+++ b/ios/Sources/Model/Author.swift
@@ -14,9 +14,3 @@ public struct Author: Equatable {
         self.name = model.name
     }
 }
-
-public extension Author {
-    var kmmModel: DroidKaigiMPP.Author {
-        .init(name: name, link: link)
-    }
-}

--- a/ios/Sources/Model/Blog.swift
+++ b/ios/Sources/Model/Blog.swift
@@ -45,21 +45,3 @@ public struct Blog: FeedItem, Equatable {
         self.language = model.language
     }
 }
-
-public extension Blog {
-    var kmmModel: DroidKaigiMPP.FeedItem.Blog {
-        .init(
-            id: id,
-            publishedAt: ConvertersKt.toKotlinInstant(publishedAt),
-            image: image.kmmModel,
-            media: media.kmmModel,
-            title: title.kmmModel,
-            summary: summary.kmmModel,
-            link: link,
-            language: language,
-            author: author.kmmModel
-        )
-    }
-
-    var _kmmModel: DroidKaigiMPP.FeedItem { kmmModel }  // swiftlint:disable:this identifier_name
-}

--- a/ios/Sources/Model/FeedItem.swift
+++ b/ios/Sources/Model/FeedItem.swift
@@ -8,14 +8,12 @@ public protocol FeedItem {
     var publishedAt: Date { get set }
     var summary: MultiLangText { get set }
     var title: MultiLangText { get set }
-    var _kmmModel: DroidKaigiMPP.FeedItem { get } // swiftlint:disable:this identifier_name
 }
 
 @dynamicMemberLookup
 public struct AnyFeedItem: Equatable {
 
     public var wrappedValue: FeedItem
-    public var kmmModel: DroidKaigiMPP.FeedItem { wrappedValue._kmmModel }
 
     public init(_ feedItem: FeedItem) {
         self.wrappedValue = feedItem

--- a/ios/Sources/Model/Image.swift
+++ b/ios/Sources/Model/Image.swift
@@ -21,13 +21,3 @@ public struct Image: Equatable {
         self.standardURLString = model.standardUrl
     }
 }
-
-public extension Image {
-    var kmmModel: DroidKaigiMPP.Image {
-        .init(
-            smallUrl: smallURLString,
-            standardUrl: standardURLString,
-            largeUrl: largeURLString
-        )
-    }
-}

--- a/ios/Sources/Model/Media.swift
+++ b/ios/Sources/Model/Media.swift
@@ -22,18 +22,3 @@ public enum Media: Equatable, CaseIterable {
         }
     }
 }
-
-public extension Media {
-    var kmmModel: DroidKaigiMPP.Media {
-        switch self {
-        case .droidKaigiFm:
-            return .DroidKaigiFM()
-        case .medium:
-            return .Medium()
-        case .youtube:
-            return .YouTube()
-        case .other:
-            return .Other()
-        }
-    }
-}

--- a/ios/Sources/Model/MultiLangText.swift
+++ b/ios/Sources/Model/MultiLangText.swift
@@ -26,9 +26,3 @@ public struct MultiLangText: Equatable {
         }
     }
 }
-
-public extension MultiLangText {
-    var kmmModel: DroidKaigiMPP.MultiLangText {
-        .init(jaTitle: jaTitle, enTitle: enTitle)
-    }
-}

--- a/ios/Sources/Model/Podcast.swift
+++ b/ios/Sources/Model/Podcast.swift
@@ -45,21 +45,3 @@ public struct Podcast: FeedItem, Equatable {
         self.speakers = model.speakers.map(Speaker.init(from:))
     }
 }
-
-public extension Podcast {
-    var kmmModel: DroidKaigiMPP.FeedItem.Podcast {
-        .init(
-            id: id,
-            publishedAt: ConvertersKt.toKotlinInstant(publishedAt),
-            image: image.kmmModel,
-            media: media.kmmModel,
-            title: title.kmmModel,
-            summary: summary.kmmModel,
-            link: link,
-            speakers: speakers.map(\.kmmModel),
-            podcastLink: podcastLink
-        )
-    }
-
-    var _kmmModel: DroidKaigiMPP.FeedItem { kmmModel }  // swiftlint:disable:this identifier_name
-}

--- a/ios/Sources/Model/Speaker.swift
+++ b/ios/Sources/Model/Speaker.swift
@@ -17,9 +17,3 @@ public struct Speaker: Equatable {
         self.iconURLString = model.iconUrl
     }
 }
-
-public extension Speaker {
-    var kmmModel: DroidKaigiMPP.Speaker {
-        .init(name: name, iconUrl: iconURLString)
-    }
-}

--- a/ios/Sources/Model/Video.swift
+++ b/ios/Sources/Model/Video.swift
@@ -37,19 +37,3 @@ public struct Video: FeedItem, Equatable {
         self.title = MultiLangText(from: model.title)
     }
 }
-
-public extension Video {
-    var kmmModel: DroidKaigiMPP.FeedItem.Video {
-        .init(
-            id: id,
-            publishedAt: ConvertersKt.toKotlinInstant(publishedAt),
-            image: image.kmmModel,
-            media: media.kmmModel,
-            title: title.kmmModel,
-            summary: summary.kmmModel,
-            link: link
-        )
-    }
-
-    var _kmmModel: DroidKaigiMPP.FeedItem { kmmModel }  // swiftlint:disable:this identifier_name
-}

--- a/ios/Sources/Repository/FeedRepository.swift
+++ b/ios/Sources/Repository/FeedRepository.swift
@@ -35,7 +35,7 @@ public struct FeedRepository: FeedRepositoryProtocol, KMMRepositoryProtocol {
 
     public func addFavorite(feedItem: AnyFeedItem) -> AnyPublisher<Void, KotlinError> {
         Future<Void, KotlinError> { promise in
-            repository.addFavorite(feedItem: feedItem.kmmModel)
+            repository.addFavorite(id: feedItem.id)
                 .subscribe(scope: scopeProvider.scope) { _ in
                     promise(.success(()))
                 } onFailure: {
@@ -47,7 +47,7 @@ public struct FeedRepository: FeedRepositoryProtocol, KMMRepositoryProtocol {
 
     public func removeFavorite(feedItem: AnyFeedItem) -> AnyPublisher<Void, KotlinError> {
         Future<Void, KotlinError> { promise in
-            repository.removeFavorite(feedItem: feedItem.kmmModel)
+            repository.removeFavorite(id: feedItem.id)
                 .subscribe(scope: scopeProvider.scope) { _ in
                     promise(.success(()))
                 } onFailure: {

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/feeder/repository/FeedRepository.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/feeder/repository/FeedRepository.kt
@@ -1,7 +1,6 @@
 package io.github.droidkaigi.feeder.repository
 
 import io.github.droidkaigi.feeder.FeedContents
-import io.github.droidkaigi.feeder.FeedItem
 import kotlinx.coroutines.flow.Flow
 
 interface FeedRepository {
@@ -9,7 +8,7 @@ interface FeedRepository {
 
     suspend fun refresh()
 
-    suspend fun addFavorite(feedItem: FeedItem)
+    suspend fun addFavorite(id: String)
 
-    suspend fun removeFavorite(feedItem: FeedItem)
+    suspend fun removeFavorite(id: String)
 }

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealFeedViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealFeedViewModel.kt
@@ -90,9 +90,9 @@ class RealFeedViewModel @Inject constructor(
                         .favorites
                         .contains(event.feedItem.id)
                     if (favorite) {
-                        repository.removeFavorite(event.feedItem)
+                        repository.removeFavorite(event.feedItem.id)
                     } else {
-                        repository.addFavorite(event.feedItem)
+                        repository.addFavorite(event.feedItem.id)
                     }
                 }
                 is FeedViewModel.Event.ReloadContent -> {


### PR DESCRIPTION
## Issue
- `FeedRepository` is hard to use by the iOS project since it requires `FeedItem` to toggle favorite

## Overview (Required)
- Adjust `FeedRepository` to toggle favorite with ID
- Remove unnecessary `kmmModel` which is using to fulfill the current requirement of `FeedRepository`

## Links
- Discussed [here](https://github.com/DroidKaigi/conference-app-2021/pull/515#discussion_r655446357)
