### PR TITLE
Display like audio spectrum during DroidKaigi FM playback

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AudioSpectrumAnimation.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AudioSpectrumAnimation.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.dp
 private const val DURATION = 600
 private val spectrumSize = 24.dp
 private val barWidth = 3.dp
-private val spacing = 1.dp
 private val maxBarHeight = 12.dp
 
 @Composable

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AudioSpectrumAnimation.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AudioSpectrumAnimation.kt
@@ -29,42 +29,38 @@ private val maxBarHeight = 12.dp
 @Composable
 fun AudioSpectrumAnimation(
     modifier: Modifier,
-    isVisible: Boolean,
-    isPlayingPodcast: Boolean,
     color: Color = MaterialTheme.colors.primary,
 ) {
-    if (isVisible && isPlayingPodcast) {
-        val offsetY = with(LocalDensity.current) { 6.dp.toPx() }
+    val offsetY = with(LocalDensity.current) { 6.dp.toPx() }
 
-        val infiniteTransition = rememberInfiniteTransition()
-        val leftBarFactor by infiniteTransition.animateHeight(
-            0.5f, 0.1f, 0.5f, 0.3f, 0.6f
-        )
-        val centerBarFactor by infiniteTransition.animateHeight(
-            0.4f, 0.65f, 0.35f, 0.6f, 0.45f
-        )
-        val rightBarFactor by infiniteTransition.animateHeight(
-            0.6f, 0.2f, 0.6f, 0.35f, 0.4f
-        )
+    val infiniteTransition = rememberInfiniteTransition()
+    val leftBarFactor by infiniteTransition.animateHeight(
+        0.5f, 0.1f, 0.5f, 0.3f, 0.6f
+    )
+    val centerBarFactor by infiniteTransition.animateHeight(
+        0.4f, 0.65f, 0.35f, 0.6f, 0.45f
+    )
+    val rightBarFactor by infiniteTransition.animateHeight(
+        0.6f, 0.2f, 0.6f, 0.35f, 0.4f
+    )
 
-        Canvas(modifier.size(spectrumSize)) {
-            rotate(180f) {
-                drawRect(
-                    color = color,
-                    topLeft = Offset(x = 6.dp.toPx(), y = offsetY),
-                    size = Size(barWidth.toPx(), maxBarHeight.toPx() * rightBarFactor)
-                )
-                drawRect(
-                    color = color,
-                    topLeft = Offset(x = 10.dp.toPx(), y = offsetY),
-                    size = Size(barWidth.toPx(), maxBarHeight.toPx() * centerBarFactor)
-                )
-                drawRect(
-                    color = color,
-                    topLeft = Offset(x = 14.dp.toPx(), y = offsetY),
-                    size = Size(barWidth.toPx(), maxBarHeight.toPx() * leftBarFactor)
-                )
-            }
+    Canvas(modifier.size(spectrumSize)) {
+        rotate(180f) {
+            drawRect(
+                color = color,
+                topLeft = Offset(x = 6.dp.toPx(), y = offsetY),
+                size = Size(barWidth.toPx(), maxBarHeight.toPx() * rightBarFactor)
+            )
+            drawRect(
+                color = color,
+                topLeft = Offset(x = 10.dp.toPx(), y = offsetY),
+                size = Size(barWidth.toPx(), maxBarHeight.toPx() * centerBarFactor)
+            )
+            drawRect(
+                color = color,
+                topLeft = Offset(x = 14.dp.toPx(), y = offsetY),
+                size = Size(barWidth.toPx(), maxBarHeight.toPx() * leftBarFactor)
+            )
         }
     }
 }

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AudioSpectrumAnimation.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AudioSpectrumAnimation.kt
@@ -1,0 +1,100 @@
+package io.github.droidkaigi.feeder.feed
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+
+private const val DURATION = 500
+private val barWidth = 3.dp
+private val spacing = 1.dp
+
+@Composable
+fun AudioSpectrumAnimation(
+    modifier: Modifier,
+    isVisible: Boolean,
+    isPlayingPodcast: Boolean,
+    color: Color = MaterialTheme.colors.primary,
+) {
+    if (isVisible && isPlayingPodcast) {
+        val offsetY = with(LocalDensity.current) {
+            4.dp.toPx()
+        }
+
+        val infiniteTransition = rememberInfiniteTransition()
+        val height1 by infiniteTransition.animateFloat(
+            initialValue = 15f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = keyframes {
+                    durationMillis = DURATION
+                    15f at 0 with FastOutSlowInEasing
+                    6f at (DURATION * 0.33).toInt() with FastOutSlowInEasing
+                    11f at (DURATION * 0.66).toInt() with FastOutSlowInEasing
+                    1f at DURATION with FastOutSlowInEasing
+                },
+                RepeatMode.Reverse
+            )
+        )
+        val height2 by infiniteTransition.animateFloat(
+            initialValue = 12f,
+            targetValue = 6f,
+            animationSpec = infiniteRepeatable(
+                animation = keyframes {
+                    durationMillis = DURATION
+                    12f at 0 with FastOutSlowInEasing
+                    6f at (DURATION * 0.33).toInt() with FastOutSlowInEasing
+                    10f at (DURATION * 0.66).toInt() with FastOutSlowInEasing
+                    6f at DURATION with FastOutSlowInEasing
+                },
+                RepeatMode.Reverse
+            )
+        )
+        val height3 by infiniteTransition.animateFloat(
+            initialValue = 7f,
+            targetValue = 12f,
+            animationSpec = infiniteRepeatable(
+                animation = keyframes {
+                    durationMillis = DURATION
+                    2f at (DURATION * 0.33).toInt() with FastOutSlowInEasing
+                    16f at (DURATION * 0.66).toInt() with FastOutSlowInEasing
+                },
+                RepeatMode.Reverse
+            )
+        )
+
+        Canvas(modifier.size(24.dp)) {
+            rotate(180f) {
+                drawRect(
+                    color = color,
+                    topLeft = Offset(x = 10.dp.toPx(), y = offsetY),
+                    size = Size(3.dp.toPx(), height1)
+                )
+                drawRect(
+                    color = color,
+                    topLeft = Offset(x = 10.dp.toPx(), y = offsetY),
+                    size = Size(3.dp.toPx(), height2)
+                )
+                drawRect(
+                    color = color,
+                    topLeft = Offset(x = 14.dp.toPx(), y = offsetY),
+                    size = Size(3.dp.toPx(), height3)
+                )
+            }
+        }
+    }
+}

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AudioSpectrumAnimation.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/AudioSpectrumAnimation.kt
@@ -39,13 +39,13 @@ fun AudioSpectrumAnimation(
 
         val infiniteTransition = rememberInfiniteTransition()
         val leftBarFactor by infiniteTransition.animateHeight(
-            0.1f, 0.5f, 0.3f
+            0.5f, 0.1f, 0.5f, 0.3f, 0.6f
         )
         val centerBarFactor by infiniteTransition.animateHeight(
-            0.7f, 0.35f, 0.6f
+            0.4f, 0.65f, 0.35f, 0.6f, 0.45f
         )
         val rightBarFactor by infiniteTransition.animateHeight(
-            0.2f, 0.6f, 0.4f
+            0.6f, 0.2f, 0.6f, 0.35f, 0.4f
         )
 
         Canvas(modifier.size(spectrumSize)) {
@@ -72,18 +72,16 @@ fun AudioSpectrumAnimation(
 
 @Composable
 private fun InfiniteTransition.animateHeight(
-    @FloatRange(from = 0.1, to = 1.0) frame1Factor: Float,
-    @FloatRange(from = 0.1, to = 1.0) frame2Factor: Float,
-    @FloatRange(from = 0.1, to = 1.0) frame3Factor: Float,
+    @FloatRange(from = 0.1, to = 1.0) vararg factors: Float,
 ): State<Float> = animateFloat(
     initialValue = 0.5f,
     targetValue = 0.5f,
     animationSpec = infiniteRepeatable(
         animation = keyframes {
             durationMillis = DURATION
-            frame1Factor at DURATION / 4
-            frame2Factor at DURATION / 2
-            frame3Factor at DURATION / 4 * 3
+            factors.forEachIndexed { index, factor ->
+                factor at DURATION / (factors.size - 1) * index
+            }
         },
         RepeatMode.Reverse
     )

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedItem.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedItem.kt
@@ -66,6 +66,7 @@ fun FeedItem(
             favoriteAnim,
             speakers,
             audioControl,
+            audioSpectrum,
         ) = createRefs()
         if (showMediaLabel) {
             Text(
@@ -114,6 +115,15 @@ fun FeedItem(
                 }
                 .clickable {
                     if (feedItem is FeedItem.Podcast) onClickPlayPodcastButton(feedItem)
+                }
+        )
+        AudioSpectrumAnimation(
+            isPlayingPodcast = isPlayingPodcast,
+            isVisible = feedItem is FeedItem.Podcast,
+            modifier = Modifier
+                .constrainAs(audioSpectrum) {
+                    linkTo(image.top, image.bottom, bias = 1.0f)
+                    linkTo(image.start, image.end, bias = 1.0f)
                 }
         )
         Text(

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedItem.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedItem.kt
@@ -117,15 +117,14 @@ fun FeedItem(
                     if (feedItem is FeedItem.Podcast) onClickPlayPodcastButton(feedItem)
                 }
         )
-        AudioSpectrumAnimation(
-            isPlayingPodcast = isPlayingPodcast,
-            isVisible = feedItem is FeedItem.Podcast,
-            modifier = Modifier
-                .constrainAs(audioSpectrum) {
+        if (feedItem is FeedItem.Podcast && isPlayingPodcast) {
+            AudioSpectrumAnimation(
+                modifier = Modifier.constrainAs(audioSpectrum) {
                     linkTo(image.top, image.bottom, bias = 1.0f)
                     linkTo(image.start, image.end, bias = 1.0f)
                 }
-        )
+            )
+        }
         Text(
             modifier = Modifier.constrainAs(title) {
                 start.linkTo(image.end, 16.dp)


### PR DESCRIPTION
## Issue
- close #381 

## Overview (Required)
- Display like audio spectrum during DroidKaigi FM playback.
- This animation is inspired by google podcast app.
- If you have better idea, please tell me feedback 😄 

## Links
-

## Screenshot

https://user-images.githubusercontent.com/7961496/123964292-3afc7700-d9ee-11eb-971e-d306da25ac17.mp4



