### PR TITLE
 Merge Dep.kt Jetpack and AndroidX Object

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -115,8 +115,8 @@ dependencies {
     testImplementation Dep.Dagger.hiltAndroidTesting
     kaptTest Dep.Dagger.hiltAndroidCompiler
 
-    implementation Dep.AndroidX.hiltCommon
-    implementation Dep.AndroidX.hiltLifeCycleViewModel
+    implementation Dep.Jetpack.hiltCommon
+    implementation Dep.Jetpack.hiltLifeCycleViewModel
     kapt Dep.Dagger.hiltAndroidCompiler
 
     implementation Dep.Compose.activity
@@ -132,12 +132,12 @@ dependencies {
         }
     }
 
-    implementation Dep.AndroidX.core
-    implementation Dep.AndroidX.fragment
-    implementation Dep.AndroidX.activity
+    implementation Dep.Jetpack.core
+    implementation Dep.Jetpack.fragment
+    implementation Dep.Jetpack.activity
 
     implementation Dep.Jetpack.appcompat
-    implementation Dep.AndroidX.lifecycle
+    implementation Dep.Jetpack.lifecycle
     implementation 'com.google.android.material:material:1.3.0'
 
     implementation Dep.FirebaseCrashlytics.android
@@ -161,7 +161,7 @@ dependencies {
     // https://github.com/cashapp/turbine/issues/10
     testImplementation 'app.cash.turbine:turbine:0.2.1'
 
-    androidTestImplementation Dep.AndroidX.Test.ext
-    androidTestImplementation Dep.AndroidX.Test.espresso
+    androidTestImplementation Dep.Jetpack.Test.ext
+    androidTestImplementation Dep.Jetpack.Test.espresso
 }
 

--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -30,6 +30,18 @@ object Dep {
         const val startup = "androidx.startup:startup-runtime:1.0.0"
         const val browser = "androidx.browser:browser:1.3.0"
         const val dataStore = "androidx.datastore:datastore-preferences:1.0.0-alpha06"
+
+        const val core = "androidx.core:core-ktx:1.5.0-beta01"
+        const val fragment = "androidx.fragment:fragment-ktx:1.3.0"
+        const val activity = "androidx.activity:activity-ktx:1.2.0"
+        const val lifecycle = "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0"
+        const val hiltCommon = "androidx.hilt:hilt-common:1.0.0-alpha03"
+        const val hiltLifeCycleViewModel = "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
+
+        object Test {
+            const val ext = "androidx.test.ext:junit:1.1.2"
+            const val espresso = "androidx.test.espresso:espresso-core:3.3.0"
+        }
     }
 
     object MultiplatformSettings {
@@ -107,20 +119,6 @@ object Dep {
 
     const val firebaseAuth = "dev.gitlive:firebase-auth:1.2.0"
     const val firebaseMessaging = "com.google.firebase:firebase-messaging-ktx:21.0.1"
-
-    object AndroidX {
-        const val core = "androidx.core:core-ktx:1.5.0-beta01"
-        const val fragment = "androidx.fragment:fragment-ktx:1.3.0"
-        const val activity = "androidx.activity:activity-ktx:1.2.0"
-        const val lifecycle = "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0"
-        const val hiltCommon = "androidx.hilt:hilt-common:1.0.0-alpha03"
-        const val hiltLifeCycleViewModel = "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
-
-        object Test {
-            const val ext = "androidx.test.ext:junit:1.1.2"
-            const val espresso = "androidx.test.espresso:espresso-core:3.3.0"
-        }
-    }
 
     const val playServicesOssLicenses = "com.google.android.gms:play-services-oss-licenses:17.0.0"
 


### PR DESCRIPTION
## Issue
- close #434

## Overview (Required)
- Move AndroidX dependencies to Jetpack object.
    - All of Androidx object were included in the Jetpack library, so merge into Jetpack object.

## Links
- None
