### PR TITLE
[iOS] fix swiftlint rule of identifier_name min_length

### DIFF
--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -7,3 +7,6 @@ excluded:
   - .build
   - Tools/.build
   - Sources/Styleguide/Generated
+
+identifier_name:
+  min_length: 2


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- fix identifier_name min length to 2

I propose this because this lint warning is occurred in the latest main branch, and it's too restrict rule.  

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
