### PR TITLE
[iOS] Refactor Tag Component

### DIFF
--- a/ios/Sources/Component/Card/LargeCard.swift
+++ b/ios/Sources/Component/Card/LargeCard.swift
@@ -5,7 +5,7 @@ import Styleguide
 public struct LargeCard: View {
     private let title: String
     private let imageURL: URL?
-    private let tag: Media
+    private let media: Media
     private let date: Date
     private let isFavorited: Bool
     private let tapAction: () -> Void
@@ -14,7 +14,7 @@ public struct LargeCard: View {
     public init(
         title: String,
         imageURL: URL?,
-        tag: Media,
+        media: Media,
         date: Date,
         isFavorited: Bool,
         tapAction: @escaping () -> Void,
@@ -22,7 +22,7 @@ public struct LargeCard: View {
     ) {
         self.title = title
         self.imageURL = imageURL
-        self.tag = tag
+        self.media = media
         self.date = date
         self.isFavorited = isFavorited
         self.tapAction = tapAction
@@ -46,9 +46,7 @@ public struct LargeCard: View {
                     .lineLimit(2)
 
                 HStack(spacing: 8) {
-                    Tag(type: tag) {
-                        // do something if needed
-                    }
+                    Tag(media: media)
 
                     Text(date.formatted)
                         .font(.caption)
@@ -77,7 +75,7 @@ public struct LargeCard_Previews: PreviewProvider {
             LargeCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: false,
                 tapAction: {},
@@ -89,7 +87,7 @@ public struct LargeCard_Previews: PreviewProvider {
             LargeCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .medium,
+                media: .medium,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},
@@ -101,7 +99,7 @@ public struct LargeCard_Previews: PreviewProvider {
             LargeCard(
                 title: "タイトル",
                 imageURL: URL(string: ""),
-                tag: .youtube,
+                media: .youtube,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},
@@ -113,7 +111,7 @@ public struct LargeCard_Previews: PreviewProvider {
             LargeCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: false,
                 tapAction: {},
@@ -125,7 +123,7 @@ public struct LargeCard_Previews: PreviewProvider {
             LargeCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .medium,
+                media: .medium,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},
@@ -137,7 +135,7 @@ public struct LargeCard_Previews: PreviewProvider {
             LargeCard(
                 title: "タイトル",
                 imageURL: URL(string: ""),
-                tag: .youtube,
+                media: .youtube,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},

--- a/ios/Sources/Component/Card/MediumCard.swift
+++ b/ios/Sources/Component/Card/MediumCard.swift
@@ -5,7 +5,7 @@ import Styleguide
 public struct MediumCard: View {
     private let title: String
     private let imageURL: URL?
-    private let tag: Media
+    private let media: Media
     private let date: Date
     private let isFavorited: Bool
     private let tapAction: () -> Void
@@ -14,7 +14,7 @@ public struct MediumCard: View {
     public init(
         title: String,
         imageURL: URL?,
-        tag: Media,
+        media: Media,
         date: Date,
         isFavorited: Bool,
         tapAction: @escaping () -> Void,
@@ -22,7 +22,7 @@ public struct MediumCard: View {
     ) {
         self.title = title
         self.imageURL = imageURL
-        self.tag = tag
+        self.media = media
         self.date = date
         self.isFavorited = isFavorited
         self.tapAction = tapAction
@@ -54,9 +54,7 @@ public struct MediumCard: View {
                 }
 
                 HStack(spacing: 8) {
-                    Tag(type: tag) {
-                        // do something if needed
-                    }
+                    Tag(media: media)
 
                     Spacer()
 
@@ -81,7 +79,7 @@ public struct MediumCard_Previews: PreviewProvider {
             MediumCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: false,
                 tapAction: {},
@@ -93,7 +91,7 @@ public struct MediumCard_Previews: PreviewProvider {
             MediumCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .medium,
+                media: .medium,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},
@@ -105,7 +103,7 @@ public struct MediumCard_Previews: PreviewProvider {
             MediumCard(
                 title: "タイトル",
                 imageURL: URL(string: ""),
-                tag: .youtube,
+                media: .youtube,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},
@@ -117,7 +115,7 @@ public struct MediumCard_Previews: PreviewProvider {
             MediumCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: false,
                 tapAction: {},
@@ -129,7 +127,7 @@ public struct MediumCard_Previews: PreviewProvider {
             MediumCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .medium,
+                media: .medium,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},
@@ -141,7 +139,7 @@ public struct MediumCard_Previews: PreviewProvider {
             MediumCard(
                 title: "タイトル",
                 imageURL: URL(string: ""),
-                tag: .youtube,
+                media: .youtube,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},

--- a/ios/Sources/Component/Card/SmallCard.swift
+++ b/ios/Sources/Component/Card/SmallCard.swift
@@ -5,7 +5,7 @@ import Styleguide
 public struct SmallCard: View {
     private let title: String
     private let imageURL: URL?
-    private let tag: Media
+    private let media: Media
     private let date: Date
     private let isFavorited: Bool
     private let tapAction: () -> Void
@@ -14,7 +14,7 @@ public struct SmallCard: View {
     public init(
         title: String,
         imageURL: URL?,
-        tag: Media,
+        media: Media,
         date: Date,
         isFavorited: Bool,
         tapAction: @escaping () -> Void,
@@ -22,7 +22,7 @@ public struct SmallCard: View {
     ) {
         self.title = title
         self.imageURL = imageURL
-        self.tag = tag
+        self.media = media
         self.date = date
         self.isFavorited = isFavorited
         self.tapAction = tapAction
@@ -53,9 +53,7 @@ public struct SmallCard: View {
                 }
 
                 HStack(spacing: 8) {
-                    Tag(type: tag) {
-                        // do something if needed
-                    }
+                    Tag(media: media)
 
                     Spacer()
 
@@ -80,7 +78,7 @@ public struct SmallCard_Previews: PreviewProvider {
             SmallCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: false,
                 tapAction: {},
@@ -92,7 +90,7 @@ public struct SmallCard_Previews: PreviewProvider {
             SmallCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .medium,
+                media: .medium,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},
@@ -104,7 +102,7 @@ public struct SmallCard_Previews: PreviewProvider {
             SmallCard(
                 title: "タイトル",
                 imageURL: URL(string: ""),
-                tag: .youtube,
+                media: .youtube,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},
@@ -116,7 +114,7 @@ public struct SmallCard_Previews: PreviewProvider {
             SmallCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: false,
                 tapAction: {},
@@ -128,7 +126,7 @@ public struct SmallCard_Previews: PreviewProvider {
             SmallCard(
                 title: "タイトルタイトルタイトルタイトルタイタイトルタイトルタイトルタイトルタイト...",
                 imageURL: URL(string: ""),
-                tag: .medium,
+                media: .medium,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},
@@ -140,7 +138,7 @@ public struct SmallCard_Previews: PreviewProvider {
             SmallCard(
                 title: "タイトル",
                 imageURL: URL(string: ""),
-                tag: .youtube,
+                media: .youtube,
                 date: Date(timeIntervalSince1970: 0),
                 isFavorited: true,
                 tapAction: {},

--- a/ios/Sources/Component/List/ListItem.swift
+++ b/ios/Sources/Component/List/ListItem.swift
@@ -8,7 +8,7 @@ public struct ListItem: View {
     }
 
     private let title: String
-    private let tag: Media
+    private let media: Media
     private let imageURL: URL?
     // TODO: Replace with real value
     private let users: [URL]
@@ -19,7 +19,7 @@ public struct ListItem: View {
 
     public init(
         title: String,
-        tag: Media,
+        media: Media,
         imageURL: URL?,
         users: [URL],
         date: Date,
@@ -28,7 +28,7 @@ public struct ListItem: View {
         tapAction: @escaping () -> Void
     ) {
         self.title = title
-        self.tag = tag
+        self.media = media
         self.imageURL = imageURL
         self.users = users
         self.date = date
@@ -39,9 +39,8 @@ public struct ListItem: View {
 
     public var body: some View {
         VStack(alignment: .leading) {
-            Tag(type: tag) {
-                // Set action if needed.
-            }
+            Tag(media: media)
+
             HStack(alignment: .top) {
                 VStack(spacing: 8) {
                     ImageView(
@@ -106,7 +105,7 @@ public struct ListItem_Previews: PreviewProvider {
         Group {
             ListItem(
                 title: "タイトルタイトルタイトルタイトルタイトルタイトルタイトルタイトルタイトルタイ...",
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 imageURL: nil,
                 users: [],
                 date: Date(timeIntervalSince1970: 0),
@@ -119,7 +118,7 @@ public struct ListItem_Previews: PreviewProvider {
             .environment(\.colorScheme, .dark)
             ListItem(
                 title: "タイトルタイトルタイトルタイトルタイトルタイトルタイトルタイトルタイトルタイ...",
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 imageURL: nil,
                 users: [],
                 date: Date(timeIntervalSince1970: 0),
@@ -131,7 +130,7 @@ public struct ListItem_Previews: PreviewProvider {
             .environment(\.colorScheme, .light)
             ListItem(
                 title: "タイトルタイトルタイトルタイトルタイトルタイトルタイトルタイトルタイトルタイ...",
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 imageURL: nil,
                 users: Array(repeating: URL(string: "https://example.com")!, count: 8),
                 date: Date(timeIntervalSince1970: 0),
@@ -144,7 +143,7 @@ public struct ListItem_Previews: PreviewProvider {
             .environment(\.colorScheme, .dark)
             ListItem(
                 title: "タイトルタイトルタイトルタイトルタイトルタイトルタイトルタイトルタイトルタイ...",
-                tag: .droidKaigiFm,
+                media: .droidKaigiFm,
                 imageURL: nil,
                 users: Array(repeating: URL(string: "https://example.com")!, count: 8),
                 date: Date(timeIntervalSince1970: 0),

--- a/ios/Sources/Component/Tag/Tag.swift
+++ b/ios/Sources/Component/Tag/Tag.swift
@@ -3,24 +3,21 @@ import SwiftUI
 import Styleguide
 
 public struct Tag: View {
-    private let type: Media
-    private let tapAction: () -> Void
+    private let media: Media
 
     public init(
-        type: Media,
-        tapAction: @escaping () -> Void
+        media: Media
     ) {
-        self.type = type
-        self.tapAction = tapAction
+        self.media = media
     }
 
     public var body: some View {
-        Text(type.title)
+        Text(media.title)
             .font(.caption)
             .foregroundColor(AssetColor.Base.white.color)
             .padding(.vertical, 4)
             .padding(.horizontal, 12)
-            .background(type.backgroundColor)
+            .background(media.backgroundColor)
             .clipShape(
                 CutCornerRectangle(
                     targetCorners: [.topLeft, .bottomRight],
@@ -34,14 +31,14 @@ public struct Tag: View {
 public struct Tag_Previews: PreviewProvider {
     public static var previews: some View {
         Group {
-            ForEach(Media.allCases, id: \.self) { type in
-                Tag(type: type, tapAction: {})
+            ForEach(Media.allCases, id: \.self) { media in
+                Tag(media: media)
                     .frame(width: 103, height: 24)
                     .environment(\.colorScheme, .light)
             }
 
-            ForEach(Media.allCases, id: \.self) { type in
-                Tag(type: type, tapAction: {})
+            ForEach(Media.allCases, id: \.self) { media in
+                Tag(media: media)
                     .frame(width: 103, height: 24)
                     .environment(\.colorScheme, .dark)
             }

--- a/ios/Sources/Component/View/FeedContentListView.swift
+++ b/ios/Sources/Component/View/FeedContentListView.swift
@@ -48,7 +48,7 @@ extension FeedContentListView {
         SmallCard(
             title: content.item.title.jaTitle,
             imageURL: URL(string: content.item.image.smallURLString),
-            tag: content.item.media,
+            media: content.item.media,
             date: content.item.publishedAt,
             isFavorited: content.isFavorited,
             tapAction: tapAction,

--- a/ios/Sources/HomeFeature/HomeScreen.swift
+++ b/ios/Sources/HomeFeature/HomeScreen.swift
@@ -119,7 +119,7 @@ private extension LargeCard {
         self.init(
             title: item.title,
             imageURL: URL(string: item.imageURLString),
-            tag: item.media,
+            media: item.media,
             date: item.publishedAt,
             isFavorited: false,
             tapAction: tapAction,
@@ -136,7 +136,7 @@ private extension ListItem {
     ) {
         self.init(
             title: item.title,
-            tag: item.media,
+            media: item.media,
             imageURL: URL(string: item.imageURLString),
             users: [],
             date: item.publishedAt,

--- a/ios/Sources/MediaFeature/MediaSection.swift
+++ b/ios/Sources/MediaFeature/MediaSection.swift
@@ -31,7 +31,7 @@ public struct MediaSection: View {
                             MediumCard(
                                 title: item.title.get(by: .ja),
                                 imageURL: URL(string: item.image.standardURLString),
-                                tag: item.media,
+                                media: item.media,
                                 date: item.publishedAt,
                                 isFavorited: content.isFavorited,
                                 tapAction: {


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- there is no use to recognize tap of tag component, so removed.
- rename the parameter name to follow the `Media` model

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
