### PR TITLE
 Fix CI by remove android emulator API 21, 23

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -11,8 +11,10 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
+        # Currently, API 21, 23 have a issue
+        # https://github.com/DroidKaigi/conference-app-2021/issues/552
         # Currently, no API 30 virtual image
-        api-level: [21, 23, 26, 29]
+        api-level: [26, 29]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Hotfix for this issue
- https://github.com/DroidKaigi/conference-app-2021/issues/552

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
