### PR TITLE
[iOS] Remove the workaround for background colors

### DIFF
--- a/ios/Sources/AboutFeature/AboutDroidKaigiScreen.swift
+++ b/ios/Sources/AboutFeature/AboutDroidKaigiScreen.swift
@@ -79,10 +79,8 @@ public struct AboutDroidKaigiScreen: View {
                 }
                 .listStyle(InsetGroupedListStyle())
             }
+            .background(AssetColor.Background.primary.color.ignoresSafeArea())
             .navigationBarTitleDisplayMode(.inline)
-            .introspectViewController { viewController in
-                viewController.view.backgroundColor = AssetColor.Background.secondary.uiColor
-            }
             .introspectNavigationController { navigationController in
                 navigationController.navigationBar.barTintColor = AssetColor.Background.secondary.uiColor
                 navigationController.navigationBar.isTranslucent = false

--- a/ios/Sources/AboutFeature/AboutScreen.swift
+++ b/ios/Sources/AboutFeature/AboutScreen.swift
@@ -74,7 +74,7 @@ public struct AboutScreen: View {
                                 .pickerStyle(SegmentedPickerStyle())
                             }
                         }
-                        .background(AssetColor.Background.primary.color)
+                        .background(AssetColor.Background.primary.color.ignoresSafeArea())
                         .navigationBarTitleDisplayMode(.inline)
                         .onAppear {
                             viewStore.send(.refresh)

--- a/ios/Sources/FavoritesFeature/FavoritesScreen.swift
+++ b/ios/Sources/FavoritesFeature/FavoritesScreen.swift
@@ -15,20 +15,23 @@ public struct FavoritesScreen: View {
 
     public var body: some View {
         NavigationView {
-            WithViewStore(store) { viewStore in
-                if viewStore.feedContents.isEmpty {
-                    Text("表示するコンテンツがありません")
-                } else {
-                    ScrollView {
-                        FeedContentListView(
-                            feedContents: viewStore.feedContents,
-                            tapContent: { content in
-                                viewStore.send(.tap(content))
-                            },
-                            tapFavorite: { isFavorited, contentId in
-                                viewStore.send(.tapFavorite(isFavorited: isFavorited, id: contentId))
-                            }
-                        )
+            ZStack {
+                AssetColor.Background.primary.color.ignoresSafeArea()
+                WithViewStore(store) { viewStore in
+                    if viewStore.feedContents.isEmpty {
+                        Text("表示するコンテンツがありません")
+                    } else {
+                        ScrollView {
+                            FeedContentListView(
+                                feedContents: viewStore.feedContents,
+                                tapContent: { content in
+                                    viewStore.send(.tap(content))
+                                },
+                                tapFavorite: { isFavorited, contentId in
+                                    viewStore.send(.tapFavorite(isFavorited: isFavorited, id: contentId))
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -42,9 +45,6 @@ public struct FavoritesScreen: View {
                         .foregroundColor(AssetColor.Base.primary.color)
                 })
             )
-            .introspectViewController { viewController in
-                viewController.view.backgroundColor = AssetColor.Background.primary.uiColor
-            }
         }
     }
 }

--- a/ios/Sources/HomeFeature/HomeScreen.swift
+++ b/ios/Sources/HomeFeature/HomeScreen.swift
@@ -55,25 +55,23 @@ public struct HomeScreen: View {
                         .separatorStyle(ThickSeparatorStyle())
                     }
                 }
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .principal) {
-                        AssetImage.logoTitle.image
-                    }
-                }
-                .navigationBarItems(
-                    trailing: Button(action: {
-                        ViewStore(store).send(.showSetting)
-                    }, label: {
-                        AssetImage.iconSetting.image
-                            .renderingMode(.template)
-                            .foregroundColor(AssetColor.Base.primary.color)
-                    })
-                )
-                .introspectViewController { viewController in
-                    viewController.view.backgroundColor = AssetColor.Background.primary.uiColor
+            }
+            .background(AssetColor.Background.primary.color.ignoresSafeArea())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    AssetImage.logoTitle.image
                 }
             }
+            .navigationBarItems(
+                trailing: Button(action: {
+                    ViewStore(store).send(.showSetting)
+                }, label: {
+                    AssetImage.iconSetting.image
+                        .renderingMode(.template)
+                        .foregroundColor(AssetColor.Base.primary.color)
+                })
+            )
         }
     }
 }

--- a/ios/Sources/MediaFeature/MediaDetailScreen.swift
+++ b/ios/Sources/MediaFeature/MediaDetailScreen.swift
@@ -30,10 +30,8 @@ public struct MediaDetailScreen: View {
                     }
                 )
             }
+            .background(AssetColor.Background.primary.color.ignoresSafeArea())
             .navigationBarTitle(viewStore.title, displayMode: .inline)
-        }
-        .introspectViewController { viewController in
-            viewController.view.backgroundColor = AssetColor.Background.primary.uiColor
         }
     }
 }

--- a/ios/Sources/MediaFeature/MediaScreen.swift
+++ b/ios/Sources/MediaFeature/MediaScreen.swift
@@ -29,6 +29,7 @@ public struct MediaScreen: View {
         NavigationView {
             WithViewStore(store) { viewStore in
                 ZStack {
+                    AssetColor.Background.primary.color.ignoresSafeArea()
                     ScrollView {
                         if viewStore.hasBlogs {
                             MediaSectionView(
@@ -128,7 +129,6 @@ public struct MediaScreen: View {
                 })
             )
             .introspectViewController { viewController in
-                viewController.view.backgroundColor = AssetColor.Background.primary.uiColor
                 guard viewController.navigationItem.searchController == nil else { return }
                 viewController.navigationItem.searchController = searchController
                 viewController.navigationItem.hidesSearchBarWhenScrolling = false

--- a/ios/Sources/SettingFeature/SettingScreen.swift
+++ b/ios/Sources/SettingFeature/SettingScreen.swift
@@ -68,6 +68,7 @@ public struct SettingScreen: View {
                 }
                 .padding(.top, 24)
             }
+            .background(AssetColor.Background.primary.color.ignoresSafeArea())
             .navigationBarTitle(L10n.SettingScreen.title, displayMode: .inline)
             .navigationBarItems(
                 trailing: Button(action: {
@@ -78,9 +79,6 @@ public struct SettingScreen: View {
                         .foregroundColor(AssetColor.Base.primary.color)
                 })
             )
-            .introspectViewController { viewController in
-                viewController.view.backgroundColor = AssetColor.Background.primary.uiColor
-            }
         }
     }
 }


### PR DESCRIPTION
## Issue

It was an issue that breaks the navigation bar style when setting background by `background(_:alignment:)` with `ignoresSafeArea(_:edges:)`, so I worked around it by assigning background colors to `viewController.view`.
But, I can't reproduce the issue, and this workaround is not working in static preview.

If someone can reproduce the issue, please tell me.
I will try to fix it with a `ZStack`, which may be a better workaround @auramagi told me.

## Overview (Required)

- Remove the workaround for background colors (The update of snapshot test reference images should be done in other auto created PR?)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/7414906/126575079-2025dd12-d53a-4073-8152-b3da4d23db57.png" width="310" /> | <img src="https://user-images.githubusercontent.com/7414906/126575076-70cb0ab2-2cc6-45f1-9e18-454210189336.png" width="300" />
