### PR TITLE
[iOS] Use view states

### DIFF
--- a/ios/Sources/AppFeature/AppTabFeature.swift
+++ b/ios/Sources/AppFeature/AppTabFeature.swift
@@ -125,8 +125,10 @@ public let appTabReducer = Reducer<AppTabState, AppTabAction, AppEnvironment>.co
             }
             state.homeState.feedContents = state.feedContents
             state.mediaState.feedContents = state.feedContents
-            if let index = state.mediaState.searchedFeedContents.map(\.id).firstIndex(of: id) {
-                state.mediaState.searchedFeedContents[index].isFavorited.toggle()
+            if var searchedFeedContents = state.mediaState.searchedFeedContents,
+                let index = searchedFeedContents.map(\.id).firstIndex(of: id) {
+                searchedFeedContents[index].isFavorited.toggle()
+                state.mediaState.searchedFeedContents = searchedFeedContents
             }
             state.favoritesState.feedContents = state.feedContents.filter(\.isFavorited)
             return .none

--- a/ios/Sources/Component/View/FeedContentListView.swift
+++ b/ios/Sources/Component/View/FeedContentListView.swift
@@ -38,7 +38,6 @@ public struct FeedContentListView: View {
             }
         }
         .padding(.horizontal, SmallCard.Const.margin)
-        .animation(.easeInOut)
     }
 }
 

--- a/ios/Sources/MediaFeature/MediaFeature.swift
+++ b/ios/Sources/MediaFeature/MediaFeature.swift
@@ -7,21 +7,18 @@ public struct MediaState: Equatable {
     // In order not to use any networks for searching feature,
     // `feedContents` is storage to search from & `searchedFeedContents` is searched result from `feedContents`
     public var feedContents: [FeedContent]
-    public var searchedFeedContents: [FeedContent]
-    var isSearchResultVisible: Bool
+    public var searchedFeedContents: [FeedContent]?
     var isSearchTextEditing: Bool
     var moreActiveType: MediaType?
 
     public init(
         feedContents: [FeedContent],
-        searchedFeedContents: [FeedContent] = [],
-        isSearchResultVisible: Bool = false,
+        searchedFeedContents: [FeedContent]? = nil,
         isSearchTextEditing: Bool = false,
         moreActiveType: MediaType? = nil
     ) {
         self.feedContents = feedContents
         self.searchedFeedContents = searchedFeedContents
-        self.isSearchResultVisible = isSearchResultVisible
         self.isSearchTextEditing = isSearchTextEditing
         self.moreActiveType = moreActiveType
     }
@@ -59,7 +56,10 @@ public struct MediaEnvironment {
 public let mediaReducer = Reducer<MediaState, MediaAction, MediaEnvironment> { state, action, _ in
     switch action {
     case let .searchTextDidChange(to: searchText):
-        state.isSearchResultVisible = !(searchText?.isEmpty ?? true)
+        guard searchText?.isEmpty == false else {
+            state.searchedFeedContents = nil
+            return .none
+        }
         if let searchText = searchText {
             state.searchedFeedContents = state.feedContents.filter { content in
                 content.item.title.jaTitle.filterForSeaching.contains(searchText.filterForSeaching)

--- a/ios/Sources/MediaFeature/MediaFeature.swift
+++ b/ios/Sources/MediaFeature/MediaFeature.swift
@@ -27,6 +27,7 @@ public struct MediaState: Equatable {
     }
 }
 
+// Only use to scope `Store`
 extension MediaState {
     var blogs: [FeedContent] {
         feedContents.filter { ($0.item.wrappedValue as? Blog) != nil }
@@ -38,22 +39,6 @@ extension MediaState {
 
     var podcasts: [FeedContent] {
         feedContents.filter { ($0.item.wrappedValue as? Podcast) != nil }
-    }
-
-    var hasBlogs: Bool {
-        !blogs.isEmpty
-    }
-
-    var hasVideos: Bool {
-        !videos.isEmpty
-    }
-
-    var hasPodcasts: Bool {
-        !podcasts.isEmpty
-    }
-
-    var isMoreActive: Bool {
-        moreActiveType != nil
     }
 }
 

--- a/ios/Sources/MediaFeature/MediaScreen.swift
+++ b/ios/Sources/MediaFeature/MediaScreen.swift
@@ -17,10 +17,14 @@ public struct MediaScreen: View {
         self._searchController = .init(
             searchBarPlaceHolder: L10n.MediaScreen.SearchBar.placeholder,
             searchTextDidChangeTo: { text in
-                viewStore.send(.searchTextDidChange(to: text))
+                withAnimation(.easeInOut) {
+                    viewStore.send(.searchTextDidChange(to: text))
+                }
             },
             isEditingDidChangeTo: { isEditing in
-                viewStore.send(.isEditingDidChange(to: isEditing))
+                withAnimation(.easeInOut) {
+                    viewStore.send(.isEditingDidChange(to: isEditing))
+                }
             }
         )
     }
@@ -47,8 +51,8 @@ public struct MediaScreen: View {
                     .zIndex(1)
 
                 Color.black.opacity(0.4)
+                    .ignoresSafeArea()
                     .opacity(viewStore.isSearchTextEditing ? 1 : .zero)
-                    .animation(.easeInOut)
                     .zIndex(2)
 
                 SearchResultScreen(
@@ -60,7 +64,6 @@ public struct MediaScreen: View {
                 .opacity(viewStore.isSearchResultVisible ? 1 : .zero)
                 .zIndex(3)
             }
-            .animation(.easeInOut)
             .background(
                 NavigationLink(
                     destination: IfLetStore(

--- a/ios/Sources/MediaFeature/MediaScreen.swift
+++ b/ios/Sources/MediaFeature/MediaScreen.swift
@@ -27,80 +27,31 @@ public struct MediaScreen: View {
 
     public var body: some View {
         NavigationView {
-            WithViewStore(store) { viewStore in
-                ZStack {
-                    AssetColor.Background.primary.color.ignoresSafeArea()
-                    ScrollView {
-                        if viewStore.hasBlogs {
-                            MediaSectionView(
-                                type: .blog,
-                                feedContent: viewStore.blogs,
-                                moreAction: {
-                                    viewStore.send(.showMore(for: .blog))
-                                },
-                                tapAction: { feedContent in
-                                    viewStore.send(.tap(feedContent))
-                                },
-                                tapFavoriteAction: { isFavorited, id in
-                                    viewStore.send(.tapFavorite(isFavorited: isFavorited, id: id))
-                                }
-                            )
-                            separator
-                        }
-                        if viewStore.hasVideos {
-                            MediaSectionView(
-                                type: .video,
-                                feedContent: viewStore.videos,
-                                moreAction: {
-                                    viewStore.send(.showMore(for: .video))
-                                },
-                                tapAction: { feedContent in
-                                    viewStore.send(.tap(feedContent))
-                                },
-                                tapFavoriteAction: { isFavorited, id in
-                                    viewStore.send(.tapFavorite(isFavorited: isFavorited, id: id))
-                                }
-                            )
-                            separator
-                        }
-                        if viewStore.hasPodcasts {
-                            MediaSectionView(
-                                type: .podcast,
-                                feedContent: viewStore.podcasts,
-                                moreAction: {
-                                    viewStore.send(.showMore(for: .podcast))
-                                },
-                                tapAction: { feedContent in
-                                    viewStore.send(.tap(feedContent))
-                                },
-                                tapFavoriteAction: { isFavorited, id in
-                                    viewStore.send(.tapFavorite(isFavorited: isFavorited, id: id))
-                                }
-                            )
-                        }
-                    }
-                    .separatorStyle(ThickSeparatorStyle())
+            ZStack {
+                AssetColor.Background.primary.color.ignoresSafeArea()
                     .zIndex(0)
 
-                    Color.black.opacity(0.4)
-                        .opacity(viewStore.isSearchTextEditing ? 1 : .zero)
-                        .animation(.easeInOut)
-                        .zIndex(1)
+                MediaListView(store: store)
+                    .zIndex(1)
 
-                    SearchResultScreen(
-                        feedContents: viewStore.searchedFeedContents,
-                        tap: { feedContent in
-                            viewStore.send(.tap(feedContent))
-                        },
-                        tapFavorite: { isFavorited, contentId in
-                            viewStore.send(.tapFavorite(isFavorited: isFavorited, id: contentId))
-                        }
-                    )
-                    .opacity(viewStore.isSearchResultVisible ? 1 : .zero)
+                Color.black.opacity(0.4)
+                    .opacity(viewStore.isSearchTextEditing ? 1 : .zero)
+                    .animation(.easeInOut)
                     .zIndex(2)
-                }
-                .animation(.easeInOut)
+
+                SearchResultScreen(
+                    feedContents: viewStore.searchedFeedContents,
+                    tap: { feedContent in
+                        viewStore.send(.tap(feedContent))
+                    },
+                    tapFavorite: { isFavorited, contentId in
+                        viewStore.send(.tapFavorite(isFavorited: isFavorited, id: contentId))
+                    }
+                )
+                .opacity(viewStore.isSearchResultVisible ? 1 : .zero)
+                .zIndex(3)
             }
+            .animation(.easeInOut)
             .background(
                 NavigationLink(
                     destination: IfLetStore(
@@ -110,7 +61,7 @@ public struct MediaScreen: View {
                         ),
                         then: MediaDetailScreen.init(store:)
                     ),
-                    isActive: ViewStore(store).binding(
+                    isActive: viewStore.binding(
                         get: \.isMoreActive,
                         send: { _ in .moreDismissed }
                     )
@@ -121,7 +72,7 @@ public struct MediaScreen: View {
             .navigationTitle(L10n.MediaScreen.title)
             .navigationBarItems(
                 trailing: Button(action: {
-                    ViewStore(store).send(.showSetting)
+                    viewStore.send(.showSetting)
                 }, label: {
                     AssetImage.iconSetting.image
                         .renderingMode(.template)

--- a/ios/Sources/MediaFeature/MediaScreen.swift
+++ b/ios/Sources/MediaFeature/MediaScreen.swift
@@ -35,7 +35,7 @@ public struct MediaScreen: View {
             isSearchTextEditing = state.isSearchTextEditing
             searchedFeedContents = state.searchedFeedContents
             isSearchResultVisible = state.isSearchResultVisible
-            isMoreActive = state.isMoreActive
+            isMoreActive = state.moreActiveType != nil
         }
     }
 

--- a/ios/Sources/MediaFeature/MediaScreen.swift
+++ b/ios/Sources/MediaFeature/MediaScreen.swift
@@ -31,12 +31,10 @@ public struct MediaScreen: View {
 
     struct ViewState: Equatable {
         var isSearchTextEditing: Bool
-        var isSearchResultVisible: Bool
         var isMoreActive: Bool
 
         init(state: MediaState) {
             isSearchTextEditing = state.isSearchTextEditing
-            isSearchResultVisible = state.isSearchResultVisible
             isMoreActive = state.moreActiveType != nil
         }
     }
@@ -55,13 +53,13 @@ public struct MediaScreen: View {
                     .opacity(viewStore.isSearchTextEditing ? 1 : .zero)
                     .zIndex(2)
 
-                SearchResultScreen(
-                    store: store.scope(
+                IfLetStore(
+                    store.scope(
                         state: \.searchedFeedContents,
                         action: MediaAction.init(action:)
-                    )
+                    ),
+                    then: SearchResultScreen.init(store:)
                 )
-                .opacity(viewStore.isSearchResultVisible ? 1 : .zero)
                 .zIndex(3)
             }
             .background(
@@ -193,7 +191,6 @@ public struct MediaScreen_Previews: PreviewProvider {
                                 .blogMock(),
                                 .blogMock()
                             ],
-                            isSearchResultVisible: true,
                             isSearchTextEditing: true
                         ),
                         reducer: .empty,

--- a/ios/Sources/MediaFeature/MediaScreen.swift
+++ b/ios/Sources/MediaFeature/MediaScreen.swift
@@ -27,13 +27,11 @@ public struct MediaScreen: View {
 
     struct ViewState: Equatable {
         var isSearchTextEditing: Bool
-        var searchedFeedContents: [FeedContent]
         var isSearchResultVisible: Bool
         var isMoreActive: Bool
 
         init(state: MediaState) {
             isSearchTextEditing = state.isSearchTextEditing
-            searchedFeedContents = state.searchedFeedContents
             isSearchResultVisible = state.isSearchResultVisible
             isMoreActive = state.moreActiveType != nil
         }
@@ -54,13 +52,10 @@ public struct MediaScreen: View {
                     .zIndex(2)
 
                 SearchResultScreen(
-                    feedContents: viewStore.searchedFeedContents,
-                    tap: { feedContent in
-                        viewStore.send(.tap(feedContent))
-                    },
-                    tapFavorite: { isFavorited, contentId in
-                        viewStore.send(.tapFavorite(isFavorited: isFavorited, id: contentId))
-                    }
+                    store: store.scope(
+                        state: \.searchedFeedContents,
+                        action: MediaAction.init(action:)
+                    )
                 )
                 .opacity(viewStore.isSearchResultVisible ? 1 : .zero)
                 .zIndex(3)
@@ -111,6 +106,15 @@ public struct MediaScreen: View {
 
 private extension MediaAction {
     init(action: MediaDetailScreen.ViewAction) {
+        switch action {
+        case .tap(let content):
+            self = .tap(content)
+        case .tapFavorite(let isFavorited, let contentId):
+            self = .tapFavorite(isFavorited: isFavorited, id: contentId)
+        }
+    }
+
+    init(action: SearchResultScreen.ViewAction) {
         switch action {
         case .tap(let content):
             self = .tap(content)

--- a/ios/Sources/MediaFeature/MediaScreen.swift
+++ b/ios/Sources/MediaFeature/MediaScreen.swift
@@ -7,12 +7,12 @@ import Styleguide
 
 public struct MediaScreen: View {
     private let store: Store<MediaState, MediaAction>
-    @ObservedObject private var viewStore: ViewStore<MediaState, MediaAction>
+    @ObservedObject private var viewStore: ViewStore<ViewState, MediaAction>
     @SearchController private var searchController: UISearchController
 
     public init(store: Store<MediaState, MediaAction>) {
         self.store = store
-        let viewStore = ViewStore(store)
+        let viewStore = ViewStore(store.scope(state: ViewState.init(state:)))
         self.viewStore = viewStore
         self._searchController = .init(
             searchBarPlaceHolder: L10n.MediaScreen.SearchBar.placeholder,
@@ -23,6 +23,20 @@ public struct MediaScreen: View {
                 viewStore.send(.isEditingDidChange(to: isEditing))
             }
         )
+    }
+
+    struct ViewState: Equatable {
+        var isSearchTextEditing: Bool
+        var searchedFeedContents: [FeedContent]
+        var isSearchResultVisible: Bool
+        var isMoreActive: Bool
+
+        init(state: MediaState) {
+            isSearchTextEditing = state.isSearchTextEditing
+            searchedFeedContents = state.searchedFeedContents
+            isSearchResultVisible = state.isSearchResultVisible
+            isMoreActive = state.isMoreActive
+        }
     }
 
     public var body: some View {

--- a/ios/Sources/MediaFeature/View/MediaListView.swift
+++ b/ios/Sources/MediaFeature/View/MediaListView.swift
@@ -20,9 +20,9 @@ struct MediaListView: View {
         var hasPodcasts: Bool
 
         init(state: MediaState) {
-            hasBlogs = !state.blogs.isEmpty
-            hasVideos = !state.videos.isEmpty
-            hasPodcasts = !state.podcasts.isEmpty
+            hasBlogs = state.feedContents.contains { $0.item.wrappedValue is Blog }
+            hasVideos = state.feedContents.contains { $0.item.wrappedValue is Video }
+            hasPodcasts = state.feedContents.contains { $0.item.wrappedValue is Podcast }
         }
     }
 

--- a/ios/Sources/MediaFeature/View/MediaListView.swift
+++ b/ios/Sources/MediaFeature/View/MediaListView.swift
@@ -1,0 +1,119 @@
+import Component
+import ComposableArchitecture
+import Model
+import Styleguide
+import SwiftUI
+
+struct MediaListView: View {
+
+    private let store: Store<MediaState, MediaAction>
+    @ObservedObject private var viewStore: ViewStore<ViewState, ViewAction>
+
+    init(store: Store<MediaState, MediaAction>) {
+        self.store = store
+        self.viewStore = .init(store.scope(state: ViewState.init(state:), action: MediaAction.init(action:)))
+    }
+
+    struct ViewState: Equatable {
+        var hasBlogs: Bool
+        var hasVideos: Bool
+        var hasPodcasts: Bool
+
+        init(state: MediaState) {
+            hasBlogs = !state.blogs.isEmpty
+            hasVideos = !state.videos.isEmpty
+            hasPodcasts = !state.podcasts.isEmpty
+        }
+    }
+
+    enum ViewAction {
+        case moreDismissed
+        case tap(FeedContent)
+        case tapFavorite(isFavorited: Bool, id: String)
+    }
+
+    var body: some View {
+        ScrollView {
+            if viewStore.hasBlogs {
+                MediaSectionView(
+                    type: .blog,
+                    store: store.scope(
+                        state: \.blogs,
+                        action: { .init(action: $0, for: .blog) }
+                    )
+                )
+                separator
+            }
+            if viewStore.hasVideos {
+                MediaSectionView(
+                    type: .video,
+                    store: store.scope(
+                        state: \.videos,
+                        action: { .init(action: $0, for: .video) }
+                    )
+                )
+                separator
+            }
+            if viewStore.hasPodcasts {
+                MediaSectionView(
+                    type: .podcast,
+                    store: store.scope(
+                        state: \.podcasts,
+                        action: { .init(action: $0, for: .podcast) }
+                    )
+                )
+            }
+        }
+        .separatorStyle(ThickSeparatorStyle())
+    }
+
+    private var separator: some View {
+        Separator()
+            .padding()
+    }
+}
+
+private extension MediaAction {
+    init(action: MediaListView.ViewAction) {
+        switch action {
+        case .moreDismissed:
+            self = .moreDismissed
+        case .tap(let feedContent):
+            self = .tap(feedContent)
+        case .tapFavorite(let isFavorited, let id):
+            self = .tapFavorite(isFavorited: isFavorited, id: id)
+        }
+    }
+}
+
+private extension MediaAction {
+    init(action: MediaSectionView.ViewAction, for mediaType: MediaType) {
+        switch action {
+        case .showMore:
+            self = .showMore(for: mediaType)
+        case .tap(let content):
+            self = .tap(content)
+        case .tapFavorite(let isFavorited, let contentId):
+            self = .tapFavorite(isFavorited: isFavorited, id: contentId)
+        }
+    }
+}
+
+#if DEBUG
+public struct MediaListView_Previews: PreviewProvider {
+    public static var previews: some View {
+        ForEach(ColorScheme.allCases, id: \.self) { colorScheme in
+            MediaListView(
+                store: .init(
+                    initialState: .init(feedContents: [.blogMock(), .blogMock(), .videoMock(), .videoMock(), .podcastMock(), .podcastMock()]),
+                    reducer: .empty,
+                    environment: {}
+                )
+            )
+            .background(AssetColor.Background.primary.color.ignoresSafeArea())
+            .environment(\.colorScheme, colorScheme)
+        }
+        .accentColor(AssetColor.primary.color)
+    }
+}
+#endif


### PR DESCRIPTION
## Issue

The `body` of almost every `View` is executed every time the `AppState` changes. So there are a lot of unnecessary executions (thanks to SwiftUI, it doesn't cost much to redraw the View, but the `body` is executed all over the place).

I don't have enough time to describe this issue in detail, so, please ask me which part is not clear directly🙇‍♂️

## Overview (Required)

- Avoid unnecessary `body` execution by `scope(state:action:)` (only accomplished in `MediaScreen` because of the limited time)
- Avoid using animation(_:)
- Avoid a weird animation when `isSearchResultVisible` and `searchedFeedContents.isEmpty` change in the same time

## Links

- https://www.pointfree.co/episodes/ep151-composable-architecture-performance-view-stores-and-scoping
