### PR TITLE
Delete unneeded lfs enable in GitHub actions

### DIFF
--- a/.github/workflows/ios-commit-snapshots.yml
+++ b/.github/workflows/ios-commit-snapshots.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          lfs: true
       - name: Create LFS file list
         run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
       - name: Restore LFS cache


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Probably it works without this option. If we can reduce using GitHub lfs cost, we want to reduce it.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
