### PR TITLE
[iOS] Reduce snapshot image size

### DIFF
--- a/ios/Tests/FavoritesFeatureTests/FavoritesFeatureTests.swift
+++ b/ios/Tests/FavoritesFeatureTests/FavoritesFeatureTests.swift
@@ -11,10 +11,6 @@ final class FavoritesFeatureTests: XCTestCase {
         assertPreviewScreenSnapshot(FavoritesScreen_Previews.self)
     }
 
-    func testFavoritesListView() {
-        assertPreviewScreenSnapshot(FavoritesListView_Previews.self)
-    }
-
     func testFavoritesEmptyView() {
         assertPreviewScreenSnapshot(FavoritesEmptyView_Previews.self)
     }

--- a/ios/Tests/HomeFeatureTests/HomeFeatureTests.swift
+++ b/ios/Tests/HomeFeatureTests/HomeFeatureTests.swift
@@ -11,10 +11,6 @@ final class HomeFeatureTests: XCTestCase {
         assertPreviewScreenSnapshot(HomeScreen_Previews.self)
     }
 
-    func testHomeListView() {
-        assertPreviewScreenSnapshot(HomeListView_Previews.self)
-    }
-
     func testQuestionnaireView() {
         assertPreviewSnapshot(QuestionnaireView_Previews.self)
     }

--- a/ios/Tests/TestUtils/PreviewSnapshot.swift
+++ b/ios/Tests/TestUtils/PreviewSnapshot.swift
@@ -2,6 +2,10 @@ import SnapshotTesting
 import SwiftUI
 import XCTest
 
+internal let traitCollectionForSnapshot: UITraitCollection = .init(traitsFrom: [
+    .init(displayScale: 0.5),
+])
+
 /// Initialize SnapshotTesting with Environment Variable
 public func initSnapshotTesting() {
     isRecording = ProcessInfo.processInfo.environment["recording"] == "true"
@@ -25,7 +29,7 @@ public func assertPreviewSnapshot<T: PreviewProvider>(
     for preview in T._allPreviews {
         assertSnapshot(
             matching: preview.content,
-            as: .image(precision: 0.9),
+            as: .image(precision: 0.9, traits: traitCollectionForSnapshot),
             record: recording,
             file: file,
             testName: testName,
@@ -58,7 +62,7 @@ public func assertPreviewScreenSnapshot<T: PreviewProvider>(
             deviceCounter[device, default: 0] += 1
             assertSnapshot(
                 matching: vc,
-                as: .image(on: device.config, precision: 0.9),
+                as: .image(on: device.config, precision: 0.9, traits: traitCollectionForSnapshot),
                 named: "\(device).\(deviceCounter[device, default: 0])",
                 record: recording,
                 file: file,


### PR DESCRIPTION
## Issue
- close None

## Overview (Required)
- Reduce iOS Snapshot image size
  - For example, 166KB -> 16KB (in my environment)
- Fix test fails

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
