### PR TITLE
Fix the link to Android Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ For Japanese speakers, please see [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md)
 
 ## Requirements
 
-Latest Android Studio **BumbleBee** and higher. You can download it from [this page]
-(https://developer
-.android.com/studio/preview).
+Latest Android Studio **BumbleBee** and higher. You can download it from [this page](https://developer.android.com/studio/preview).
 Xcode version is 12.4 (If you do iOS development)
 
 # Tech Stacks


### PR DESCRIPTION
## Issue
- Maybe no issues.

## Overview (Required)
- The link to Android Studio is broken.



## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5885032/130739292-f9383000-bf20-46a9-8802-cf94c2bff919.png" width="300" /> | <img src="" width="300" />
