### PR TITLE
[iOS] navigate to license

### DIFF
--- a/ios/Sources/AboutFeature/AboutDroidKaigiScreen.swift
+++ b/ios/Sources/AboutFeature/AboutDroidKaigiScreen.swift
@@ -60,7 +60,18 @@ public struct AboutDroidKaigiScreen: View {
 
                 List {
                     ForEach(AboutDroidKaigiModel.allCases, id: \.self) { model in
-                        Button(action: {}, label: {
+                        Button(action: {
+                            switch model {
+                            case .behaviorCode:
+                                return // TODO: add navigation
+                            case .opensourceLicense:
+                                if let url = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(url) {
+                                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                                }
+                            case .privacyPolicy:
+                                break // TODO: add navigation
+                            }
+                        }, label: {
                             HStack {
                                 Text(model.title)
                                     .font(.subheadline)


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- navigate to setting app & goes directly to DroidKaigi 2021 app. This does not directly show license page, but shows one page behind license page.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
