### PR TITLE
Settings exported attribute

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:theme="@style/Theme.ConferenceAppFeeder">
         <activity
             android:name="io.github.droidkaigi.feeder.MainActivity"
+            android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.ConferenceAppFeeder.NoActionBar">
             <intent-filter>


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- If this app targets Android 12, you need to explicitly declare the `android:exported` attribute.
- This app is targets Android 11, but I think no problem to support it in advance.

## Links
- https://developer.android.com/about/versions/12/behavior-changes-12#exported

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
