### PR TITLE
Update lfs-asset-id as well in update snapshot PR

### DIFF
--- a/.github/workflows/ios-commit-snapshots.yml
+++ b/.github/workflows/ios-commit-snapshots.yml
@@ -49,10 +49,18 @@ jobs:
       - name: Add LFS tracked file
         run: |
           git lfs track "**/__Snapshots__/*/*.png"
+      - name: Create Snapshots commit
+        run: |
+          git add -A
+          git commit -m "[iOS] Update iOS Snapshots"
+      - name: Create Updated asset-id commit
+        run: |
+          git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+          git add -A
+          git commit -m "Update asset-id"
       - name: Create Update Snapshots PullRequest
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: "[iOS] Update iOS Snapshots"
           branch: update-ios-snapshots
           delete-branch: true
           branch-suffix: short-commit-hash


### PR DESCRIPTION
## Issue
- close None

## Overview (Required)
- Currently in iOS snapshot pr, the `ios-commit-snapshot` action creates two pull requests. So I fix it to once.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
