### PR TITLE
Use navigation scoped viewmodel

### DIFF
--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FeedScreen.kt
@@ -458,7 +458,7 @@ fun PreviewFeedScreen() {
     AppThemeWithBackground {
         CompositionLocalProvider(
             provideFeedViewModelFactory { fakeFeedViewModel() },
-            fmPlayerViewModelProviderValue(fakeFmPlayerViewModel())
+            provideFmPlayerViewModelFactory { fakeFmPlayerViewModel() }
         ) {
             FeedScreen(
                 selectedTab = FeedTab.Home,
@@ -479,7 +479,7 @@ fun PreviewDarkFeedScreen() {
     ) {
         CompositionLocalProvider(
             provideFeedViewModelFactory { fakeFeedViewModel() },
-            fmPlayerViewModelProviderValue(fakeFmPlayerViewModel())
+            provideFmPlayerViewModelFactory { fakeFmPlayerViewModel() }
         ) {
             FeedScreen(
                 selectedTab = FeedTab.Home,
@@ -498,7 +498,7 @@ fun PreviewFeedScreenWithStartBlog() {
     AppThemeWithBackground {
         CompositionLocalProvider(
             provideFeedViewModelFactory { fakeFeedViewModel() },
-            fmPlayerViewModelProviderValue(fakeFmPlayerViewModel())
+            provideFmPlayerViewModelFactory { fakeFmPlayerViewModel() }
         ) {
             FeedScreen(
                 selectedTab = FeedTab.FilteredFeed.Blog,

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FmPlayerViewModel.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FmPlayerViewModel.kt
@@ -35,7 +35,7 @@ private val LocalFmPlayerViewModelFactory =
         {
             error("not LocalFmPlayerViewModel provided")
         }
-}
+    }
 
 fun provideFmPlayerViewModelFactory(viewModelFactory: @Composable () -> FmPlayerViewModel) =
     LocalFmPlayerViewModelFactory provides viewModelFactory

--- a/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FmPlayerViewModel.kt
+++ b/uicomponent-compose/feed/src/main/java/io/github/droidkaigi/feeder/feed/FmPlayerViewModel.kt
@@ -30,12 +30,15 @@ interface FmPlayerViewModel : UnidirectionalViewModel<FmPlayerViewModel.Event,
     override fun event(event: Event)
 }
 
-private val LocalFmPlayerViewModel = compositionLocalOf<FmPlayerViewModel> {
-    error("not LocalFmPlayerViewModel provided")
+private val LocalFmPlayerViewModelFactory =
+    compositionLocalOf<@Composable () -> FmPlayerViewModel> {
+        {
+            error("not LocalFmPlayerViewModel provided")
+        }
 }
 
-fun fmPlayerViewModelProviderValue(viewModel: FmPlayerViewModel) =
-    LocalFmPlayerViewModel provides viewModel
+fun provideFmPlayerViewModelFactory(viewModelFactory: @Composable () -> FmPlayerViewModel) =
+    LocalFmPlayerViewModelFactory provides viewModelFactory
 
 @Composable
-fun fmPlayerViewModel() = LocalFmPlayerViewModel.current
+fun fmPlayerViewModel() = LocalFmPlayerViewModelFactory.current()

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
@@ -3,10 +3,8 @@ package io.github.droidkaigi.feeder.viewmodel
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.viewmodel.compose.viewModel
-import io.github.droidkaigi.feeder.contributor.contributorViewModelProviderValue
 import io.github.droidkaigi.feeder.contributor.fakeContributorViewModel
-import io.github.droidkaigi.feeder.feed.fmPlayerViewModelProviderValue
+import io.github.droidkaigi.feeder.contributor.provideContributorViewModelFactory
 import io.github.droidkaigi.feeder.feed.provideFeedViewModelFactory
 import io.github.droidkaigi.feeder.feed.provideFmPlayerViewModelFactory
 import io.github.droidkaigi.feeder.provideAppViewModelFactory
@@ -20,7 +18,7 @@ fun ProvideViewModels(content: @Composable () -> Unit) {
         provideFeedViewModelFactory { hiltViewModel<RealFeedViewModel>() },
         provideSettingViewModelFactory { hiltViewModel<RealSettingViewModel>() },
         provideStaffViewModelFactory { (hiltViewModel<RealStaffViewModel>()) },
-        contributorViewModelProviderValue(fakeContributorViewModel()),
+        provideContributorViewModelFactory { fakeContributorViewModel() },
         provideFmPlayerViewModelFactory { hiltViewModel<RealFmPlayerViewModel>() },
         content = content
     )

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
@@ -8,6 +8,7 @@ import io.github.droidkaigi.feeder.contributor.contributorViewModelProviderValue
 import io.github.droidkaigi.feeder.contributor.fakeContributorViewModel
 import io.github.droidkaigi.feeder.feed.fmPlayerViewModelProviderValue
 import io.github.droidkaigi.feeder.feed.provideFeedViewModelFactory
+import io.github.droidkaigi.feeder.feed.provideFmPlayerViewModelFactory
 import io.github.droidkaigi.feeder.provideAppViewModelFactory
 import io.github.droidkaigi.feeder.setting.provideSettingViewModelFactory
 import io.github.droidkaigi.feeder.staff.provideStaffViewModelFactory
@@ -20,7 +21,7 @@ fun ProvideViewModels(content: @Composable () -> Unit) {
         provideSettingViewModelFactory { hiltViewModel<RealSettingViewModel>() },
         provideStaffViewModelFactory { (hiltViewModel<RealStaffViewModel>()) },
         contributorViewModelProviderValue(fakeContributorViewModel()),
-        fmPlayerViewModelProviderValue(viewModel<RealFmPlayerViewModel>()),
+        provideFmPlayerViewModelFactory { hiltViewModel<RealFmPlayerViewModel>() },
         content = content
     )
 }

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/ProvideRealViewModels.kt
@@ -10,7 +10,7 @@ import io.github.droidkaigi.feeder.feed.fmPlayerViewModelProviderValue
 import io.github.droidkaigi.feeder.feed.provideFeedViewModelFactory
 import io.github.droidkaigi.feeder.provideAppViewModelFactory
 import io.github.droidkaigi.feeder.setting.provideSettingViewModelFactory
-import io.github.droidkaigi.feeder.staff.staffViewModelProviderValue
+import io.github.droidkaigi.feeder.staff.provideStaffViewModelFactory
 
 @Composable
 fun ProvideViewModels(content: @Composable () -> Unit) {
@@ -18,7 +18,7 @@ fun ProvideViewModels(content: @Composable () -> Unit) {
         provideAppViewModelFactory { hiltViewModel<RealAppViewModel>() },
         provideFeedViewModelFactory { hiltViewModel<RealFeedViewModel>() },
         provideSettingViewModelFactory { hiltViewModel<RealSettingViewModel>() },
-        staffViewModelProviderValue(viewModel<RealStaffViewModel>()),
+        provideStaffViewModelFactory { (hiltViewModel<RealStaffViewModel>()) },
         contributorViewModelProviderValue(fakeContributorViewModel()),
         fmPlayerViewModelProviderValue(viewModel<RealFmPlayerViewModel>()),
         content = content

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorItem.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorItem.kt
@@ -66,7 +66,9 @@ fun ContributorItem(contributor: Contributor, onClickItem: (Contributor) -> Unit
 fun PreviewContributorItem() {
     ConferenceAppFeederTheme {
         val contributor = fakeContributors().first()
-        CompositionLocalProvider(provideContributorViewModelFactory { fakeContributorViewModel() }) {
+        CompositionLocalProvider(provideContributorViewModelFactory {
+            fakeContributorViewModel()
+        }) {
             ContributorItem(contributor = contributor) {
             }
         }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorItem.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorItem.kt
@@ -66,9 +66,11 @@ fun ContributorItem(contributor: Contributor, onClickItem: (Contributor) -> Unit
 fun PreviewContributorItem() {
     ConferenceAppFeederTheme {
         val contributor = fakeContributors().first()
-        CompositionLocalProvider(provideContributorViewModelFactory {
-            fakeContributorViewModel()
-        }) {
+        CompositionLocalProvider(
+            provideContributorViewModelFactory {
+                fakeContributorViewModel()
+            }
+        ) {
             ContributorItem(contributor = contributor) {
             }
         }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorItem.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorItem.kt
@@ -66,7 +66,7 @@ fun ContributorItem(contributor: Contributor, onClickItem: (Contributor) -> Unit
 fun PreviewContributorItem() {
     ConferenceAppFeederTheme {
         val contributor = fakeContributors().first()
-        CompositionLocalProvider(contributorViewModelProviderValue(fakeContributorViewModel())) {
+        CompositionLocalProvider(provideContributorViewModelFactory { fakeContributorViewModel() }) {
             ContributorItem(contributor = contributor) {
             }
         }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorList.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorList.kt
@@ -46,9 +46,11 @@ fun ContributorList(onContributorClick: (Contributor) -> Unit) {
 @Composable
 fun PreviewContributorScreen() {
     ConferenceAppFeederTheme {
-        CompositionLocalProvider(provideContributorViewModelFactory {
-            fakeContributorViewModel()
-        }) {
+        CompositionLocalProvider(
+            provideContributorViewModelFactory {
+                fakeContributorViewModel()
+            }
+        ) {
             ContributorList() {
             }
         }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorList.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorList.kt
@@ -46,7 +46,9 @@ fun ContributorList(onContributorClick: (Contributor) -> Unit) {
 @Composable
 fun PreviewContributorScreen() {
     ConferenceAppFeederTheme {
-        CompositionLocalProvider(provideContributorViewModelFactory { fakeContributorViewModel() }) {
+        CompositionLocalProvider(provideContributorViewModelFactory {
+            fakeContributorViewModel()
+        }) {
             ContributorList() {
             }
         }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorList.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorList.kt
@@ -46,7 +46,7 @@ fun ContributorList(onContributorClick: (Contributor) -> Unit) {
 @Composable
 fun PreviewContributorScreen() {
     ConferenceAppFeederTheme {
-        CompositionLocalProvider(contributorViewModelProviderValue(fakeContributorViewModel())) {
+        CompositionLocalProvider(provideContributorViewModelFactory { fakeContributorViewModel() }) {
             ContributorList() {
             }
         }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorViewModel.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorViewModel.kt
@@ -30,12 +30,15 @@ interface ContributorViewModel :
     override fun event(event: Event)
 }
 
-private val LocalContributeViewModel = compositionLocalOf<ContributorViewModel> {
-    error("Not view model provided")
+private val LocalContributeViewModelFactory =
+    compositionLocalOf<@Composable () -> ContributorViewModel> {
+        {
+            error("Not view model provided")
+        }
 }
 
-fun contributorViewModelProviderValue(viewModel: ContributorViewModel) =
-    LocalContributeViewModel provides viewModel
+fun provideContributorViewModelFactory(viewModelFactory: @Composable () -> ContributorViewModel) =
+    LocalContributeViewModelFactory provides viewModelFactory
 
 @Composable
-fun contributeViewModel() = LocalContributeViewModel.current
+fun contributeViewModel() = LocalContributeViewModelFactory.current()

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorViewModel.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/contributor/ContributorViewModel.kt
@@ -35,7 +35,7 @@ private val LocalContributeViewModelFactory =
         {
             error("Not view model provided")
         }
-}
+    }
 
 fun provideContributorViewModelFactory(viewModelFactory: @Composable () -> ContributorViewModel) =
     LocalContributeViewModelFactory provides viewModelFactory

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffItem.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffItem.kt
@@ -80,7 +80,7 @@ fun StaffItem(staff: Staff, onClickItem: (Staff) -> Unit) {
 fun PreviewStaffItem() {
     ConferenceAppFeederTheme {
         val staff = fakeStaffs().first()
-        CompositionLocalProvider(staffViewModelProviderValue(fakeStaffViewModel())) {
+        CompositionLocalProvider(provideStaffViewModelFactory { fakeStaffViewModel() }) {
             StaffItem(staff = staff) {
             }
         }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffList.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffList.kt
@@ -46,7 +46,7 @@ fun StaffList(onStaffClick: (Staff) -> Unit) {
 @Composable
 fun PreviewStaffScreen() {
     ConferenceAppFeederTheme {
-        CompositionLocalProvider(staffViewModelProviderValue(fakeStaffViewModel())) {
+        CompositionLocalProvider(provideStaffViewModelFactory { fakeStaffViewModel() }) {
             StaffList {}
         }
     }

--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffViewModel.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/staff/StaffViewModel.kt
@@ -26,11 +26,14 @@ interface StaffViewModel :
     override fun event(event: Event)
 }
 
-private val LocalStaffViewModel = compositionLocalOf<StaffViewModel> {
-    error("Not view model provided")
+private val LocalStaffViewModelFactory = compositionLocalOf<@Composable () -> StaffViewModel> {
+    {
+        error("Not view model provided")
+    }
 }
 
-fun staffViewModelProviderValue(viewModel: StaffViewModel) = LocalStaffViewModel provides viewModel
+fun provideStaffViewModelFactory(viewModelFactory: @Composable () -> StaffViewModel) =
+    LocalStaffViewModelFactory provides viewModelFactory
 
 @Composable
-fun staffViewModel() = LocalStaffViewModel.current
+fun staffViewModel() = LocalStaffViewModelFactory.current()


### PR DESCRIPTION
## Issue
- close #609 

## Overview (Required)
- Now, We can use navigation destination scoped ViewModel. (Currently we use Activity scoped ViewModels)

## Links
- I referred to https://github.com/DroidKaigi/conference-app-2021/pull/608

## Screenshot

There is no change in appearance, so I will omit it.
