### PR TITLE
Lower minSdkVersion to 21 and re-enable tests

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -11,10 +11,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # Currently, API 21, 23 have a issue
-        # https://github.com/DroidKaigi/conference-app-2021/issues/552
         # Currently, no API 30 virtual image
-        api-level: [26, 29]
+        api-level: [21, 23, 26, 29]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         applicationId "io.github.droidkaigi.feeder"
-        minSdkVersion 24
+        minSdkVersion 21
         targetSdkVersion 30
         versionCode AppVersions.versionCode
         versionName AppVersions.versionName

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -3,7 +3,7 @@ android {
     buildToolsVersion "30.0.2"
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 21
         targetSdkVersion 30
     }
 


### PR DESCRIPTION
## Issue
- close #552

## Overview
Originally [tests were disabled](https://github.com/DroidKaigi/conference-app-2021/pull/553) for API level 21 and 23 because they failed to run. This was caused by [this bug](https://issuetracker.google.com/issues/193810678) in AGP which is [now fixed](https://issuetracker.google.com/issues/193810678#comment5). Later on, the `minSdkVersion` [was increased](https://github.com/DroidKaigi/conference-app-2021/commit/ea0396657c896a5931189e05a541cdb05d62c977) to work around another bug in AGP which is also fixed now. So this PR reverts the previous changes because a new enough version of AGP is being used which fixes the bugs.

## Links
- https://issuetracker.google.com/issues/193810678
