### PR TITLE
[iOS] Run CI on `macOS 11 Big Sur` host runner

### DIFF
--- a/.github/workflows/ios-commit-snapshots.yml
+++ b/.github/workflows/ios-commit-snapshots.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   take-snapshots:
     name: "iOS Take and Commit Snapshots"
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Create LFS file list
@@ -28,7 +28,7 @@ jobs:
         with:
           java-version: '11'
       - name: Select Xcode Version
-        run: sudo xcode-select -s '/Applications/Xcode_12.4.app'
+        run: sudo xcode-select -s '/Applications/Xcode_12.5.1.app'
       - name: Show Xcode Version
         run: xcodebuild -version
       - uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -12,11 +12,13 @@ jobs:
       javaVersion: ${{ steps.set-java-version.outputs.javaVersion }}
     steps:
       - id: set-xcode-path
+        name: Set Xcode path
         run: |
-          xcode_version='13.0'
+          xcode_version='12.5'
           xcode_path="/Applications/Xcode_${xcode_version}.app"
           echo "::set-output name=xcodePath::$xcode_path"
       - id: set-java-version
+        name: Set Java version
         run: |
           java_version='11'
           echo "::set-output name=javaVersion::$java_version"

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -5,16 +5,32 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  setup-versions:
+    runs-on: macos-11
+    outputs:
+      xcodePath: ${{ steps.set-xcode-path.outputs.xcodePath }}
+      javaVersion: ${{ steps.set-java-version.outputs.javaVersion }}
+    steps:
+      - id: set-xcode-path
+        run: |
+          xcode_version='12.4' 
+          xcode_path="/Applications/Xcode_${xcode_version}.app"
+          echo "::set-output name=xcodePath::$xcode_path"
+      - id: set-java-version
+        run: |
+          java_version='11'
+          echo "::set-output name=javaVersion::$java_version"
   build-modules:
     name: "iOS Buid Test for Modules"
     runs-on: macos-11
+    needs: setup-versions
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: ${{ needs.setup-versions.outputs.javaVersion }}
       - name: Select Xcode Version
-        run: sudo xcode-select -s '/Applications/Xcode_12.4.app'
+        run: sudo xcode-select -s "${{ needs.setup-versions.outputs.xcodePath }}"
       - name: Show Xcode Version
         run: xcodebuild -version
       - uses: eskatos/gradle-command-action@v1
@@ -36,6 +52,7 @@ jobs:
   test-modules:
     name: "iOS Test for Modules"
     runs-on: macos-11
+    needs: setup-versions
     steps:
       - uses: actions/checkout@v2
       - name: Create LFS file list
@@ -50,9 +67,9 @@ jobs:
         run: git lfs pull
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: ${{ needs.setup-versions.outputs.javaVersion }}
       - name: Select Xcode Version
-        run: sudo xcode-select -s '/Applications/Xcode_12.4.app'
+        run: sudo xcode-select -s "${{ needs.setup-versions.outputs.xcodePath }}"
       - name: Show Xcode Version
         run: xcodebuild -version
       - uses: eskatos/gradle-command-action@v1
@@ -74,13 +91,14 @@ jobs:
   build-app-debug:
     name: "iOS Buid Test on Debug Configuration"
     runs-on: macos-11
+    needs: setup-versions
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: ${{ needs.setup-versions.outputs.javaVersion }}
       - name: Select Xcode Version
-        run: sudo xcode-select -s '/Applications/Xcode_12.4.app'
+        run: sudo xcode-select -s "${{ needs.setup-versions.outputs.xcodePath }}"
       - name: Show Xcode Version
         run: xcodebuild -version
       - uses: eskatos/gradle-command-action@v1
@@ -102,13 +120,14 @@ jobs:
   build-app-release:
     name: "iOS Buid Test on Release Configuration"
     runs-on: macos-11
+    needs: setup-versions
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: ${{ needs.setup-versions.outputs.javaVersion }}
       - name: Select Xcode Version
-        run: sudo xcode-select -s '/Applications/Xcode_12.4.app'
+        run: sudo xcode-select -s "${{ needs.setup-versions.outputs.xcodePath }}"
       - name: Show Xcode Version
         run: xcodebuild -version
       - uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   setup-versions:
-    runs-on: macos-11
+    runs-on: ubuntu-latest
     outputs:
       xcodePath: ${{ steps.set-xcode-path.outputs.xcodePath }}
       javaVersion: ${{ steps.set-java-version.outputs.javaVersion }}

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -14,7 +14,7 @@ jobs:
       - id: set-xcode-path
         name: Set Xcode path
         run: |
-          xcode_version='12.5'
+          xcode_version='12.5.1'
           xcode_path="/Applications/Xcode_${xcode_version}.app"
           echo "::set-output name=xcodePath::$xcode_path"
       - id: set-java-version

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - id: set-xcode-path
         run: |
-          xcode_version='12.4' 
+          xcode_version='13.0'
           xcode_path="/Applications/Xcode_${xcode_version}.app"
           echo "::set-output name=xcodePath::$xcode_path"
       - id: set-java-version

--- a/.github/workflows/ios-test.yml
+++ b/.github/workflows/ios-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-modules:
     name: "iOS Buid Test for Modules"
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -35,7 +35,7 @@ jobs:
 
   test-modules:
     name: "iOS Test for Modules"
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - name: Create LFS file list
@@ -73,7 +73,7 @@ jobs:
 
   build-app-debug:
     name: "iOS Buid Test on Debug Configuration"
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -101,7 +101,7 @@ jobs:
 
   build-app-release:
     name: "iOS Buid Test on Release Configuration"
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -13,7 +13,7 @@ jobs:
       github.event_name == 'pull_request' &&
       !contains(github.event.pull_request.head.ref, 'main')
     name: "ios test on feature branches"
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: Get HEAD to fetch
         id: fetch-head
@@ -30,7 +30,7 @@ jobs:
         with:
           java-version: '11'
       - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_12.4.app'
+        run: sudo xcode-select -s '/Applications/Xcode_13.0.app'
       - name: Show Xcode version
         run: xcodebuild -version
       - uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           java-version: '11'
       - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_13.0.app'
+        run: sudo xcode-select -s '/Applications/Xcode_12.5.app'
       - name: Show Xcode version
         run: xcodebuild -version
       - uses: eskatos/gradle-command-action@v1

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           java-version: '11'
       - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_12.5.app'
+        run: sudo xcode-select -s '/Applications/Xcode_12.5.1.app'
       - name: Show Xcode version
         run: xcodebuild -version
       - uses: eskatos/gradle-command-action@v1

--- a/ios/scripts/generate-license-list.sh
+++ b/ios/scripts/generate-license-list.sh
@@ -5,7 +5,7 @@ set -e
 cd "$(dirname "$0")/.."
 
 xcrun --sdk macosx swift run -c release --package-path Tools license-plist \
-  --package-path DroidKaigi2021.xcworkspace/xcshareddata/swiftpm/Package.resolved \
+  --swift-package-path DroidKaigi2021.xcworkspace/xcshareddata/swiftpm/Package.resolved \
   --output-path DroidKaigi\ 2021/DroidKaigi\ 2021/Settings.bundle \
   --add-version-numbers \
   --suppress-opening-directory

--- a/ios/scripts/xcodebuild.sh
+++ b/ios/scripts/xcodebuild.sh
@@ -6,7 +6,7 @@ CONFIGURATION=${3}
 
 SWIFT_RUN="swift run -c release --package-path Tools"
 WORKSPACE=DroidKaigi2021.xcworkspace
-PLATFORM_IOS="iOS Simulator,name=iPhone 12 Pro,OS=14.4"
+PLATFORM_IOS="iOS Simulator,name=iPhone 12 Pro,OS=14.5"
 
 echo "⚙️  Building $SCHEME..."
 set -o pipefail && xcodebuild $TYPE \


### PR DESCRIPTION
## Issue
- close #642

## Overview (Required)
- Switch GitHub Actions host runner to `Big Sur` for iOS App
- Run each workflows with Xcode 12.5.1
- Unfortunately, trying to run with Xcode 13 has failed on [Gradle task](https://github.com/DroidKaigi/conference-app-2021/runs/3666160658?check_suite_focus=true).
  - It seems that KMM is not supporting Xcode 13 (or Swift 5.5) yet.
- There are multiple `sudo xcode-select -s ~` steps in `ios-test` workflow, so I made it easier to change Xcode path.
- fix argument on `generate-license-list` (`--package-path` -> `--swift-package-path`)

## Links
- mono0926/LicensePlist#156

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
