### PR TITLE
fix crash when pause fm player while preparing state

### DIFF
--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealFmPlayerViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealFmPlayerViewModel.kt
@@ -6,14 +6,12 @@ import android.media.MediaPlayer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.droidkaigi.feeder.feed.FmPlayerViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class RealFmPlayerViewModel : FmPlayerViewModel, ViewModel() {
 
@@ -28,13 +26,12 @@ class RealFmPlayerViewModel : FmPlayerViewModel, ViewModel() {
         )
     }
 
-    @Suppress("BlockingMethodInNonBlockingContext")
-    private suspend fun play(url: String) = withContext(Dispatchers.IO) {
+    private fun play(url: String) {
         fmPlayer.run {
             reset()
             setDataSource(url)
-            prepare()
-            start()
+            prepareAsync()
+            setOnPreparedListener { mp -> mp?.start() }
         }
     }
 
@@ -43,7 +40,10 @@ class RealFmPlayerViewModel : FmPlayerViewModel, ViewModel() {
     }
 
     private fun pause() {
-        fmPlayer.pause()
+        fmPlayer.run {
+            pause()
+            setOnPreparedListener(null)
+        }
     }
 
     override val effect: Flow<FmPlayerViewModel.Effect> = effectSharedFlow.receiveAsFlow()

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealFmPlayerViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealFmPlayerViewModel.kt
@@ -41,7 +41,9 @@ class RealFmPlayerViewModel : FmPlayerViewModel, ViewModel() {
 
     private fun pause() {
         fmPlayer.run {
-            pause()
+            if (isPlaying) {
+                pause()
+            }
             setOnPreparedListener(null)
         }
     }


### PR DESCRIPTION
## Issue
- close #525

## Overview (Required)
- fix crash when pause fm player while preparing state

### Details
There seemed to be a problem with MediaPlayer::prepare method, which is a synchronous process, being executed on IO Dispatchers.
We were able to avoid this problem by using MediaPlayer::prepareAsync, which is an asynchronous process.
Using OnPreparedListener, MediaPlayer::start is executed when prepare is completed.

crash stacktrace

```
2021-09-23 15:48:23.005 14192-14192/io.github.droidkaigi.feeder.debug E/MediaPlayerNative: pause called in state 4, mPlayer(0x756c53a6d0)
2021-09-23 15:48:23.005 14192-14192/io.github.droidkaigi.feeder.debug E/MediaPlayerNative: error (-38, 0)
2021-09-23 15:48:23.190 14192-14192/io.github.droidkaigi.feeder.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.github.droidkaigi.feeder.debug, PID: 14192
    java.lang.IllegalStateException
        at android.media.MediaPlayer._prepare(Native Method)
        at android.media.MediaPlayer.prepare(MediaPlayer.java:1277)
        at io.github.droidkaigi.feeder.viewmodel.RealFmPlayerViewModel$play$2.invokeSuspend(RealFmPlayerViewModel.kt:36)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

## Links
-

## Screen Record
### Before

https://user-images.githubusercontent.com/32016001/134511641-e576f72b-83d3-4493-9942-5b6a2538d142.mp4

### After

https://user-images.githubusercontent.com/32016001/134511735-7cc82334-353d-4bd0-a37b-323507a17709.mp4


