### PR TITLE
Fix wrong date tab name

### DIFF
--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
@@ -34,8 +34,8 @@ import io.github.droidkaigi.feeder.core.use
 
 sealed class TimetableTab(val name: String, val routePath: String, val day: DroidKaigi2021Day) {
     object Day1 : TimetableTab("Day1", "day1", DroidKaigi2021Day.Day1)
-    object Day2 : TimetableTab("Day1", "day1", DroidKaigi2021Day.Day2)
-    object Day3 : TimetableTab("Day1", "day1", DroidKaigi2021Day.Day3)
+    object Day2 : TimetableTab("Day2", "day2", DroidKaigi2021Day.Day2)
+    object Day3 : TimetableTab("Day3", "day3", DroidKaigi2021Day.Day3)
 
     companion object {
         fun values() = listOf(Day1, Day2, Day3)


### PR DESCRIPTION
## Issue
- close #686

## Overview (Required)
- Changed the date and route path strings to the appropriate ones.

## Links
- NA

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/38500329/135179380-50ff1344-2575-43b2-be66-bd5d63a8513c.jpg" width="300" /> | <img src="https://user-images.githubusercontent.com/38500329/135179166-2c8f6bf5-12fe-4f49-93d5-fdfa92cfdcfe.jpg" width="300" />
