### PR TITLE
[iOS] make error view little better

### DIFF
--- a/ios/Sources/AboutFeature/AboutDroidKaigiScreen.swift
+++ b/ios/Sources/AboutFeature/AboutDroidKaigiScreen.swift
@@ -68,7 +68,7 @@ public struct AboutDroidKaigiScreen: View {
                 }
                 .introspectTableView { tableView in
                     tableView.isScrollEnabled = false
-                    tableView.backgroundColor = .clear
+                    tableView.backgroundColor = AssetColor.Background.primary.uiColor
                 }
                 .listStyle(InsetGroupedListStyle())
             }

--- a/ios/Sources/Component/View/ErrorView.swift
+++ b/ios/Sources/Component/View/ErrorView.swift
@@ -9,16 +9,25 @@ public struct ErrorView: View {
     }
 
     public var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 32) {
             Text(L10n.Component.ErrorView.title)
+                .font(.title2)
+                .bold()
+                .foregroundColor(AssetColor.Base.primary.color)
 
-            Button(
-                action: tapReload,
-                label: {
-                    Text(L10n.Component.ErrorView.reload)
-                        .foregroundColor(AssetColor.primary.color)
+            Button(action: tapReload, label: {
+                Text(L10n.Component.ErrorView.reload)
+                    .font(.headline)
+                    .bold()
+                    .foregroundColor(Color.white)
             })
+            .padding(.vertical, 10)
+            .padding(.horizontal, 24)
+            .background(AssetColor.primary.color)
+            .cornerRadius(20)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AssetColor.Background.primary.color.ignoresSafeArea())
     }
 }
 


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- fix errorView snapshot problem
- make design little bit nice.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

<img width="287" alt="スクリーンショット 2021-09-30 1 12 22" src="https://user-images.githubusercontent.com/27538852/135307751-59dc5d53-48fa-4e89-914b-298ca3c09279.png">

