### PR TITLE
Filtering favorites from the Timetable items

### DIFF
--- a/ios-framework/src/iosMain/kotlin/io/github/droidkaigi/feeder/repository/IosLanguageRepository.kt
+++ b/ios-framework/src/iosMain/kotlin/io/github/droidkaigi/feeder/repository/IosLanguageRepository.kt
@@ -1,8 +1,8 @@
 package io.github.droidkaigi.feeder.repository
 
+import io.github.droidkaigi.feeder.Lang
 import io.github.droidkaigi.feeder.NonNullSuspendWrapper
 import io.github.droidkaigi.feeder.NullableFlowWrapper
-import io.github.droidkaigi.feeder.Lang
 
 interface IosLanguageRepository {
     fun changeLanguage(language: Lang): NonNullSuspendWrapper<Unit>

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/feeder/TimetableContents.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/feeder/TimetableContents.kt
@@ -7,7 +7,23 @@ import kotlinx.datetime.toInstant
 data class TimetableContents(
     val timetableItems: TimetableItemList = TimetableItemList(),
     val favorites: Set<String> = setOf(),
-)
+) {
+    val contents by lazy {
+        timetableItems.map {
+            it to favorites.contains(it.id)
+        }
+    }
+
+    fun filtered(filters: Filters): TimetableContents {
+        var timetableItems = timetableItems.toList()
+        if (filters.filterFavorite) {
+            timetableItems = timetableItems.filter { timetableItem ->
+                favorites.contains(timetableItem.id)
+            }
+        }
+        return copy(timetableItems = TimetableItemList(timetableItems))
+    }
+}
 
 fun TimetableContents?.orEmptyContents(): TimetableContents = this ?: TimetableContents()
 fun LoadState<TimetableContents>.getContents() = getValueOrNull() ?: TimetableContents()

--- a/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealTimetableViewModel.kt
+++ b/uicomponent-compose/main/src/main/java/io/github/droidkaigi/feeder/viewmodel/RealTimetableViewModel.kt
@@ -61,12 +61,13 @@ class RealTimetableViewModel @Inject constructor(
             allTimetableContents,
             filters,
             showProgressLatch.toggleState,
-        ) { feedContentsLoadState, _, showProgress ->
-            val timetableContents =
-                feedContentsLoadState.getValueOrNull().orEmptyContents()
+        ) { feedContentsLoadState, filters, showProgress ->
+            val filteredTimetableContents =
+                feedContentsLoadState.getValueOrNull().orEmptyContents().filtered(filters)
             TimetableViewModel.State(
                 showProgress = showProgress,
-                timetableContents = timetableContents
+                filters = filters,
+                filteredTimetableContents = filteredTimetableContents
 //                snackbarMessage = currentValue.snackbarMessage
             )
         }

--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/BackLayerContent.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/BackLayerContent.kt
@@ -26,12 +26,12 @@ enum class FilterState(val text: String) {
 }
 
 @Composable
-fun BackLayerContent (
+fun BackLayerContent(
     filterState: Filters,
     onFavoriteFilterChanged: (filtered: Boolean) -> Unit,
 ) {
     Column(
-    modifier = Modifier.padding(vertical = 12.dp)
+        modifier = Modifier.padding(vertical = 12.dp)
     ) {
         Input(
             text = FilterState.Favorite.text,

--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/BackLayerContent.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/BackLayerContent.kt
@@ -1,0 +1,88 @@
+package io.github.droidkaigi.feeder.timetable2021
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckBox
+import androidx.compose.material.icons.rounded.CheckBoxOutlineBlank
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.github.droidkaigi.feeder.Filters
+
+enum class FilterState(val text: String) {
+    Favorite("Favorites")
+}
+
+@Composable
+fun BackLayerContent (
+    filterState: Filters,
+    onFavoriteFilterChanged: (filtered: Boolean) -> Unit,
+) {
+    Column(
+    modifier = Modifier.padding(vertical = 12.dp)
+    ) {
+        Input(
+            text = FilterState.Favorite.text,
+            isChecked = filterState.filterFavorite,
+            onClick = {
+                onFavoriteFilterChanged(!filterState.filterFavorite)
+            }
+        )
+    }
+}
+
+@Composable
+private fun Input(
+    text: String,
+    isChecked: Boolean = false,
+    onClick: () -> Unit,
+) {
+    Row(
+        Modifier
+            .clickable(onClick = onClick)
+            .fillMaxWidth()
+            .padding(all = 12.dp)
+    ) {
+        Icon(
+            imageVector = if (isChecked) {
+                Icons.Rounded.CheckBox
+            } else {
+                Icons.Rounded.CheckBoxOutlineBlank
+            },
+            contentDescription = "filter $text"
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            modifier = Modifier
+                .align(Alignment.CenterVertically),
+            text = text,
+            style = MaterialTheme.typography.body1
+        )
+        Spacer(Modifier.width(8.dp))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewBackLayerContent() {
+    Conference2021Theme {
+        Surface(color = MaterialTheme.colors.primary) {
+            BackLayerContent(
+                filterState = Filters(),
+                onFavoriteFilterChanged = { }
+            )
+        }
+    }
+}

--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/FakeTimetableViewModel.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/FakeTimetableViewModel.kt
@@ -58,9 +58,11 @@ class FakeTimetableViewModel(val errorFetchData: Boolean) : TimetableViewModel {
     private val filters: MutableStateFlow<Filters> = MutableStateFlow(Filters())
 
     override val state: StateFlow<TimetableViewModel.State> =
-        combine(mTimetableContents, filters) { feedContents, _ ->
+        combine(mTimetableContents, filters) { timetableContents, filters ->
+            val filteredTimetableContents = timetableContents.filtered(filters)
             TimetableViewModel.State(
-                timetableContents = feedContents,
+                filters = filters,
+                filteredTimetableContents = filteredTimetableContents,
             )
         }
             .stateIn(coroutineScope, SharingStarted.Eagerly, TimetableViewModel.State())

--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableItem.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableItem.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.feeder.timetable2021
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -22,7 +21,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow

--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.BackdropValue
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.SnackbarHost
-import androidx.compose.material.Text
 import androidx.compose.material.primarySurface
 import androidx.compose.material.rememberBackdropScaffoldState
 import androidx.compose.runtime.Composable
@@ -26,6 +25,7 @@ import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
 import io.github.droidkaigi.feeder.DroidKaigi2021Day
+import io.github.droidkaigi.feeder.Filters
 import io.github.droidkaigi.feeder.TimetableContents
 import io.github.droidkaigi.feeder.TimetableItem
 import io.github.droidkaigi.feeder.TimetableItemList
@@ -83,6 +83,14 @@ fun TimetableScreen(
                 TimetableViewModel.Event.ToggleFavorite(timetableItem = timetableItem)
             )
         },
+        filters = state.filters,
+        onFavoriteFilterChanged = {
+            dispatch(
+                TimetableViewModel.Event.ChangeFavoriteFilter(
+                    filters = state.filters.copy(filterFavorite = it)
+                )
+            )
+        }
     )
 }
 
@@ -97,6 +105,8 @@ private fun TimetableScreen(
     onSelectTab: (TimetableTab) -> Unit,
     onDetailClick: (String) -> Unit,
     onFavoriteChange: (TimetableItem) -> Unit,
+    filters: Filters,
+    onFavoriteFilterChanged: (filtered: Boolean) -> Unit,
 ) {
     Conference2021Theme() {
         val density = LocalDensity.current
@@ -104,8 +114,7 @@ private fun TimetableScreen(
             backLayerBackgroundColor = MaterialTheme.colors.primarySurface,
             scaffoldState = state.scaffoldState,
             backLayerContent = {
-                // TODO
-                Text(text = "Implement me!!!!")
+                BackLayerContent(filters, onFavoriteFilterChanged)
             },
             frontLayerShape = MaterialTheme.shapes.large,
             peekHeight = 104.dp + (LocalWindowInsets.current.systemBars.top / density.density).dp,

--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
@@ -71,7 +71,7 @@ fun TimetableScreen(
 
     TimetableScreen(
         state = TimetableScreenState(
-            timeTableContents = state.timetableContents,
+            timeTableContents = state.filteredTimetableContents.timetableItems,
             scaffoldState = scaffoldState,
             tabPagerState = pagerState
         ),

--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
@@ -71,7 +71,7 @@ fun TimetableScreen(
 
     TimetableScreen(
         state = TimetableScreenState(
-            timeTableContents = state.filteredTimetableContents.timetableItems,
+            timeTableContents = state.filteredTimetableContents,
             scaffoldState = scaffoldState,
             tabPagerState = pagerState
         ),

--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableViewModel.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableViewModel.kt
@@ -16,7 +16,8 @@ interface TimetableViewModel :
         .State> {
     data class State(
         val showProgress: Boolean = false,
-        val timetableContents: TimetableContents = fakeTimetableContents(),
+        val filters: Filters = Filters(),
+        val filteredTimetableContents: TimetableContents = fakeTimetableContents(),
     )
 
     sealed class Effect {


### PR DESCRIPTION
## Issue
- close #626 

## Overview (Required)
- On the Timetable, we can use the favorite feature like the Feed screen.
- BUT, the favorite counter is not yet included.

## Screenshot
FeedScreen| TimetableScreen
:--: | :--:
<img src="https://user-images.githubusercontent.com/58973616/135618132-b564adff-bf66-402a-a8ed-ca7be325ecb6.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/58973616/135617607-aeea5dc6-6229-401e-ba29-4b16ca2b93a4.gif" width="300" />


