### PR TITLE
Stop centering when filtering in timetable screen

### DIFF
--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableScreen.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.feeder.timetable2021
 
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -168,6 +169,7 @@ private fun TimetableList(
     state: TimetableListState,
 ) {
     LazyColumn(
+        modifier = Modifier.fillMaxHeight(),
         contentPadding = rememberInsetsPaddingValues(
             insets = LocalWindowInsets.current.systemBars,
             applyStart = false,


### PR DESCRIPTION
## Issue
- close #716 

## Overview (Required)
- Set fillMaxHeight modifier to LazyColumn in TimetableScreen

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13119930/136064069-e557feb4-9551-4e1c-b9e0-3b1d84a440b3.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13119930/136064132-b66ec57b-ead2-4a9a-bdc5-aede96ad0970.png" width="300" />
