### PR TITLE
items in dialog set as center verticaly of alignment

### DIFF
--- a/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/setting/Setting.kt
+++ b/uicomponent-compose/other/src/main/java/io/github/droidkaigi/feeder/setting/Setting.kt
@@ -194,7 +194,8 @@ private fun ThemeSelectRadioButton(
                                 oThemeSelected(theme)
                                 onChangeTheme(theme)
                             }
-                        )
+                        ),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     RadioButton(
                         selected = (theme == selectedTheme),


### PR DESCRIPTION
## Issue
- close #736

## Overview (Required)
- Set verticalAlignment as CenterVertically

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/41291352/137691802-63604000-6bb1-44bc-8c29-a99a4dc22342.png" width="300" /> | <img src="https://user-images.githubusercontent.com/41291352/137735124-1f137286-0595-49e9-9d18-17037d361343.png" width="300" />
<img src="https://user-images.githubusercontent.com/41291352/137735680-212c10fa-660c-4901-a16b-579359bde8ae.png" width="300" /> | <img src="https://user-images.githubusercontent.com/41291352/137735265-65cc01fe-279b-4b16-a55c-9b64c1653edc.png" width="300" />