### PR TITLE
Enable R8 for release builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,7 +62,7 @@ android {
             }
         }
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }


### PR DESCRIPTION
## Overview (Required)
Enabling R8 optimization is strongly recommended for Jetpack Compose and there are significant performance differences between un-optimized builds and optimized builds ([source](https://kotlinlang.slack.com/archives/CJLTWPH7S/p1630248475315600?thread_ts=1630247931.314700&cid=CJLTWPH7S)).
Enabling R8 shrinked the APK size from 14.0M to 4.4M and reduced first launch time by ~20% in my local test.
There doesn't seem to be any problems with serialization after enabling R8.