### PR TITLE
Rearrange preview annotation

### DIFF
--- a/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableDetailScreen.kt
+++ b/uicomponent-compose/timetable2021/src/main/java/io/github/droidkaigi/feeder/timetable2021/TimetableDetailScreen.kt
@@ -621,6 +621,10 @@ private val TimetableCategory.iconResId: Int
 // region default preview
 
 @Preview
+@Preview(widthDp = 360)
+@Preview(device = Devices.NEXUS_7_2013)
+@Preview(device = Devices.NEXUS_10)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewTimetableDetailScreen() {
     AppThemeWithBackground {
@@ -630,70 +634,6 @@ fun PreviewTimetableDetailScreen() {
             TimetableDetailScreen(
                 id = TimetableItemId("2"),
                 onNavigationIconClick = {},
-            )
-        }
-    }
-}
-
-// endregion
-
-// region optional preview
-
-@Preview(widthDp = 360)
-@Composable
-fun PreviewSmallTimetableDetailScreen() {
-    AppThemeWithBackground {
-        CompositionLocalProvider(
-            provideTimetableDetailViewModelFactory { fakeTimetableDetailViewModel() },
-        ) {
-            TimetableDetailScreen(
-                id = TimetableItemId("2"),
-                onNavigationIconClick = {}
-            )
-        }
-    }
-}
-
-@Preview(device = Devices.NEXUS_7_2013)
-@Composable
-fun PreviewTabletTimetableDetailScreen() {
-    AppThemeWithBackground {
-        CompositionLocalProvider(
-            provideTimetableDetailViewModelFactory { fakeTimetableDetailViewModel() },
-        ) {
-            TimetableDetailScreen(
-                id = TimetableItemId("2"),
-                onNavigationIconClick = {}
-            )
-        }
-    }
-}
-
-@Preview(device = Devices.NEXUS_10)
-@Composable
-fun PreviewLargeTabletTimetableDetailScreen() {
-    AppThemeWithBackground {
-        CompositionLocalProvider(
-            provideTimetableDetailViewModelFactory { fakeTimetableDetailViewModel() },
-        ) {
-            TimetableDetailScreen(
-                id = TimetableItemId("2"),
-                onNavigationIconClick = {}
-            )
-        }
-    }
-}
-
-@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Composable
-fun PreviewDarkTimetableDetailScreen() {
-    AppThemeWithBackground {
-        CompositionLocalProvider(
-            provideTimetableDetailViewModelFactory { fakeTimetableDetailViewModel() },
-        ) {
-            TimetableDetailScreen(
-                id = TimetableItemId("2"),
-                onNavigationIconClick = {}
             )
         }
     }


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Previews can be displayed multiple times without writing multiple copies of the same function.

## Links
- https://www.youtube.com/watch?v=DfzDV22Xfkw (DroidKaigi Day 3/[What's new in Android Studio ~ Arctic Fox & Bumblebee ~](https://droidkaigi.jp/2021/timetable/277369?day=3))
  - mhidaka introduced that multiple Previews can be enumerated by writing multiple `@Preview`.

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
