### PR TITLE
bump agp and hilt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.0-beta02'
+        classpath 'com.android.tools.build:gradle:7.1.0-beta05'
         classpath Dep.Kotlin.bom
         classpath Dep.Kotlin.plugin
         classpath Dep.Kotlin.stdlibJdk8

--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -99,10 +99,10 @@ object Dep {
     const val exhaustivePlugin = "app.cash.exhaustive:exhaustive-gradle:0.2.0"
 
     object Dagger {
-        const val plugin = "com.google.dagger:hilt-android-gradle-plugin:2.37"
-        const val hiltAndroid = "com.google.dagger:hilt-android:2.37"
-        const val hiltAndroidTesting = "com.google.dagger:hilt-android-testing:2.37"
-        const val hiltAndroidCompiler = "com.google.dagger:hilt-android-compiler:2.37"
+        const val plugin = "com.google.dagger:hilt-android-gradle-plugin:2.40.5"
+        const val hiltAndroid = "com.google.dagger:hilt-android:2.40.5"
+        const val hiltAndroidTesting = "com.google.dagger:hilt-android-testing:2.40.5"
+        const val hiltAndroidCompiler = "com.google.dagger:hilt-android-compiler:2.40.5"
     }
 
     object Accompanist {


### PR DESCRIPTION
## Issue
- no ref

## Overview (Required)
- bump age and hilt to build on Android Studio Bumblebee | 2021.1.1 Beta 5

## Links
- reason why I update hilt is [here](https://stackoverflow.com/questions/67890567/unable-to-find-method-void-com-android-build-api-extension-androidcomponentsex)

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
