### PR TITLE
Update AGP 7.1.0-rc01 and Hilt 2.40.5

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -42,11 +42,13 @@
         </activity>
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
-            android:theme="@style/Theme.ConferenceAppFeeder" />
+            android:theme="@style/Theme.ConferenceAppFeeder"
+            tools:ignore="MissingClass" /><!-- False positive MissingClass lint error if using AGP 7.1.0-rc1 -->
 
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
-            android:theme="@style/Theme.ConferenceAppFeeder" />
+            android:theme="@style/Theme.ConferenceAppFeeder"
+            tools:ignore="MissingClass" /><!-- False positive MissingClass lint error if using AGP 7.1.0-rc1 -->
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.0-beta02'
+        classpath 'com.android.tools.build:gradle:7.1.0-rc01'
         classpath Dep.Kotlin.bom
         classpath Dep.Kotlin.plugin
         classpath Dep.Kotlin.stdlibJdk8

--- a/buildSrc/src/main/java/Dep.kt
+++ b/buildSrc/src/main/java/Dep.kt
@@ -99,10 +99,10 @@ object Dep {
     const val exhaustivePlugin = "app.cash.exhaustive:exhaustive-gradle:0.2.0"
 
     object Dagger {
-        const val plugin = "com.google.dagger:hilt-android-gradle-plugin:2.37"
-        const val hiltAndroid = "com.google.dagger:hilt-android:2.37"
-        const val hiltAndroidTesting = "com.google.dagger:hilt-android-testing:2.37"
-        const val hiltAndroidCompiler = "com.google.dagger:hilt-android-compiler:2.37"
+        const val plugin = "com.google.dagger:hilt-android-gradle-plugin:2.40.5"
+        const val hiltAndroid = "com.google.dagger:hilt-android:2.40.5"
+        const val hiltAndroidTesting = "com.google.dagger:hilt-android-testing:2.40.5"
+        const val hiltAndroidCompiler = "com.google.dagger:hilt-android-compiler:2.40.5"
     }
 
     object Accompanist {


### PR DESCRIPTION
## Overview (Required)

- Update AGP 7.1.0-rc01 
- Update Hilt 2.40.5
  - Why this update is needed?
    - https://stackoverflow.com/questions/67890567/unable-to-find-method-void-com-android-build-api-extension-androidcomponentsex

## Links
-
